### PR TITLE
fix(update): use minimal chainload helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(CORE_SOURCES
     src/core/peer.c
     src/core/piece.c
     src/core/tracker.c
+    src/core/mse.c
     src/core/dht.c
     src/core/torrent.c
     src/platform/storage.c
@@ -116,6 +117,7 @@ set(CORE_SOURCES
 )
 
 set(APP_SERVICE_SOURCES
+    src/app/update_transaction.c
     src/app/app_settings.cpp
     src/app/update_service.cpp
     src/app/catalog_batch_installer.cpp
@@ -144,6 +146,20 @@ set(UI_SOURCES
 )
 
 if (NOT PIPENSX_GOLDEN)
+
+program_target(pipensx_updater
+    "src/update_helper.c;src/app/update_transaction.c;src/core/sha256.c")
+set_target_properties(pipensx_updater PROPERTIES
+    C_STANDARD 11
+)
+target_include_directories(pipensx_updater PRIVATE src)
+target_compile_definitions(pipensx_updater PRIVATE __SWITCH__)
+target_compile_options(pipensx_updater PRIVATE
+    -Wall
+    -Wextra
+    -ffunction-sections
+    -fdata-sections
+)
 
 set(APP_SOURCES
     ${CORE_SOURCES}
@@ -201,6 +217,14 @@ target_link_libraries(pipensx PRIVATE
 )
 
 file(MAKE_DIRECTORY ${ROMFS_DIR})
+add_custom_target(sync_update_helper ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${ROMFS_DIR}"
+    COMMAND ${NX_ELF2NRO_EXE}
+        pipensx_updater.elf "${ROMFS_DIR}/pipensx-updater.nro"
+    DEPENDS pipensx_updater
+    BYPRODUCTS "${ROMFS_DIR}/pipensx-updater.nro"
+    VERBATIM
+)
 file(COPY
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/borealis/resources/img/sys
     DESTINATION ${ROMFS_DIR}/img
@@ -228,6 +252,7 @@ if (NOT EXISTS "${PIPENSX_CATALOG_SNAPSHOT_ABS}")
         "PIPENSX_CATALOG_SNAPSHOT does not exist: ${PIPENSX_CATALOG_SNAPSHOT_ABS}")
 endif ()
 set(PIPENSX_NRO_DEPENDS pipensx)
+list(APPEND PIPENSX_NRO_DEPENDS sync_update_helper)
 add_custom_target(sync_catalog_snapshot ALL
     COMMAND ${CMAKE_COMMAND} -E make_directory "${ROMFS_DIR}/catalog"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/Makefile.pc
+++ b/Makefile.pc
@@ -55,6 +55,7 @@ PEER_TEST_TARGET = tests/test_peer
 TORRENT_TEST_TARGET = tests/test_torrent
 SETTINGS_TEST_TARGET = tests/test_app_settings
 UPDATE_TEST_TARGET = tests/test_update_service
+UPDATE_TRANSACTION_TEST_TARGET = tests/test_update_transaction
 INSTALL_SPACE_TEST_TARGET = tests/test_install_space
 BATCH_INSTALL_TEST_TARGET = tests/test_batch_install
 RAM_BUDGET_TEST_TARGET = tests/test_stream_ram_budget
@@ -148,6 +149,7 @@ test: $(TEST_TARGET) $(MANAGER_TEST_TARGET) $(PACKAGE_TEST_TARGET) \
 		$(CATALOG_TEST_TARGET) \
 		$(TELEMETRY_TEST_TARGET) $(PEER_TEST_TARGET) \
 		$(TORRENT_TEST_TARGET) $(SETTINGS_TEST_TARGET) $(UPDATE_TEST_TARGET) \
+		$(UPDATE_TRANSACTION_TEST_TARGET) \
 		$(INSTALL_SPACE_TEST_TARGET) $(BATCH_INSTALL_TEST_TARGET) \
 		$(RAM_BUDGET_TEST_TARGET) $(REQUEST_GATE_TEST_TARGET) \
 		$(JOURNAL_TEST_TARGET) $(WEB_SEED_TEST_TARGET) \
@@ -161,6 +163,7 @@ test: $(TEST_TARGET) $(MANAGER_TEST_TARGET) $(PACKAGE_TEST_TARGET) \
 	./$(TORRENT_TEST_TARGET)
 	./$(SETTINGS_TEST_TARGET)
 	./$(UPDATE_TEST_TARGET)
+	./$(UPDATE_TRANSACTION_TEST_TARGET)
 	./$(INSTALL_SPACE_TEST_TARGET)
 	./$(BATCH_INSTALL_TEST_TARGET)
 	./$(RAM_BUDGET_TEST_TARGET)
@@ -173,8 +176,13 @@ test: $(TEST_TARGET) $(MANAGER_TEST_TARGET) $(PACKAGE_TEST_TARGET) \
 $(SETTINGS_TEST_TARGET): tests/test_app_settings.cpp src/app/app_settings.cpp
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
 
-$(UPDATE_TEST_TARGET): tests/test_update_service.cpp src/app/update_service.cpp src/core/sha256.c
+$(UPDATE_TEST_TARGET): tests/test_update_service.cpp src/app/update_service.cpp \
+		src/app/update_transaction.o src/core/sha256.c
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS) -Wl,--wrap=rename
+
+$(UPDATE_TRANSACTION_TEST_TARGET): tests/test_update_transaction.c \
+		src/app/update_transaction.c src/core/sha256.c
+	$(CC) $(CFLAGS) -Isrc -o $@ $^ -Wl,--wrap=rename
 
 $(INSTALL_SPACE_TEST_TARGET): tests/test_install_space.cpp \
 		src/app/install_space.cpp
@@ -235,8 +243,9 @@ clean:
 		$(CATALOG_TEST_TARGET) \
 		$(TELEMETRY_TEST_TARGET) $(PEER_TEST_TARGET) \
 		$(TORRENT_TEST_TARGET) $(SETTINGS_TEST_TARGET) $(UPDATE_TEST_TARGET) \
+		$(UPDATE_TRANSACTION_TEST_TARGET) \
 		$(INSTALL_SPACE_TEST_TARGET) $(BATCH_INSTALL_TEST_TARGET) \
 		$(RAM_BUDGET_TEST_TARGET) $(REQUEST_GATE_TEST_TARGET) \
-		$(JOURNAL_TEST_TARGET)
+		$(JOURNAL_TEST_TARGET) $(MSE_TEST_TARGET)
 
 .PHONY: all test clean

--- a/src/app/game_metadata_service.cpp
+++ b/src/app/game_metadata_service.cpp
@@ -147,7 +147,8 @@ bool httpGetOnce(const std::string& url, size_t limit,
                  std::vector<uint8_t>& data, std::string& error,
                  bool followRedirects = true,
                  std::string* effectiveUrl = nullptr,
-                 bool verifyTls = false) {
+                 bool verifyTls = false,
+                 const std::atomic<bool>* stopping = nullptr) {
     data.clear();
     CURL* curl = curl_easy_init();
     if (!curl) {
@@ -168,6 +169,14 @@ bool httpGetOnce(const std::string& url, size_t limit,
     curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeBytes);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buffer);
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION,
+        +[](void* opaque, curl_off_t, curl_off_t, curl_off_t, curl_off_t) {
+            const auto* flag = static_cast<const std::atomic<bool>*>(opaque);
+            return flag && flag->load(std::memory_order_relaxed) ? 1 : 0;
+        });
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA,
+                     const_cast<std::atomic<bool>*>(stopping));
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, verifyTls ? 1L : 0L);
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, verifyTls ? 2L : 0L);
     curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
@@ -244,10 +253,12 @@ std::string ddgRelayUrl(const std::string& sourceUrl) {
 #endif
 
 bool httpGet(const std::string& url, size_t limit, std::vector<uint8_t>& data,
-             std::string& error) {
+             std::string& error,
+             const std::atomic<bool>* stopping = nullptr) {
     auto attempt = [&](const std::string& requestUrl) {
         std::string attemptError;
-        if (!httpGetOnce(requestUrl, limit, data, attemptError)) {
+        if (!httpGetOnce(requestUrl, limit, data, attemptError, true, nullptr,
+                         false, stopping)) {
             error = std::move(attemptError);
             return false;
         }
@@ -424,9 +435,11 @@ std::string manifestIndexSha(const std::string& json) {
 }
 
 bool fetchTrustedMetadata(const std::string& url, size_t limit,
-                          std::vector<uint8_t>& data, std::string& error) {
+                          std::vector<uint8_t>& data, std::string& error,
+                          const std::atomic<bool>* stopping = nullptr) {
     std::string effectiveUrl;
-    if (!httpGetOnce(url, limit, data, error, true, &effectiveUrl, true))
+    if (!httpGetOnce(url, limit, data, error, true, &effectiveUrl, true,
+                     stopping))
         return false;
     if (!GameMetadataService::isTrustedRedirect(effectiveUrl)) {
         data.clear();
@@ -468,10 +481,11 @@ GameMetadataService::GameMetadataService(std::string rootPath,
       manifestUrl_(std::move(manifestUrl)),
       metadataFetcher_(std::move(metadataFetcher)) {
     if (!metadataFetcher_) {
-        metadataFetcher_ = [](const std::string& url, size_t limit,
-                              std::vector<uint8_t>& data,
-                              std::string& error) {
-            return fetchTrustedMetadata(url, limit, data, error);
+        metadataFetcher_ = [this](const std::string& url, size_t limit,
+                                  std::vector<uint8_t>& data,
+                                  std::string& error) {
+            return fetchTrustedMetadata(url, limit, data, error,
+                                        &stoppingRequested_);
         };
     }
     makeDirectories(cacheRoot_);
@@ -482,6 +496,7 @@ GameMetadataService::GameMetadataService(std::string rootPath,
 }
 
 GameMetadataService::~GameMetadataService() {
+    stoppingRequested_.store(true, std::memory_order_relaxed);
     std::vector<ImageCallback> cancelled;
     {
         std::lock_guard<std::mutex> lock(imageMutex_);
@@ -872,7 +887,7 @@ GameMetadataService::ImageLoadResult GameMetadataService::loadImageInternal(
         error = "Image network deferred during active transfer.";
         return ImageLoadResult::Deferred;
     }
-    if (!httpGet(url, kMaxImageBytes, bytes, error))
+    if (!httpGet(url, kMaxImageBytes, bytes, error, &stoppingRequested_))
         return ImageLoadResult::Failed;
     if (bytes.size() < 8) {
         error = "Downloaded image is too small.";

--- a/src/app/game_metadata_service.hpp
+++ b/src/app/game_metadata_service.hpp
@@ -145,6 +145,7 @@ private:
     mutable size_t imageCacheBytes_ = 0;
     mutable uint64_t imageAccess_ = 0;
     mutable std::atomic<bool> imageNetworkPaused_{false};
+    mutable std::atomic<bool> stoppingRequested_{false};
     mutable bool stoppingImages_ = false;
     std::unordered_map<std::string, GameMetadata> byHash_;
     MetadataManifest manifest_;

--- a/src/app/update_service.cpp
+++ b/src/app/update_service.cpp
@@ -1,4 +1,5 @@
 #include "update_service.hpp"
+#include "update_transaction.h"
 
 #include <curl/curl.h>
 #include <borealis/extern/nlohmann/json.hpp>
@@ -15,6 +16,10 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+#ifdef __SWITCH__
+#include <switch.h>
+#endif
 
 extern "C" {
 #include "core/sha256.h"
@@ -91,13 +96,21 @@ int enlargeSocketBuffer(void*, curl_socket_t socket, curlsocktype purpose) {
     return CURL_SOCKOPT_OK;
 }
 
+struct TransferProgress {
+    const UpdateService::ProgressCallback* callback;
+    const std::atomic<bool>* stopping;
+};
+
 int reportTransferProgress(void* opaque, curl_off_t downloadTotal,
                            curl_off_t downloadNow, curl_off_t, curl_off_t) {
-    const auto* progress =
-        static_cast<const UpdateService::ProgressCallback*>(opaque);
-    if (progress && *progress && downloadTotal > 0)
-        (*progress)(static_cast<uint64_t>(downloadNow),
-                    static_cast<uint64_t>(downloadTotal));
+    const auto* progress = static_cast<const TransferProgress*>(opaque);
+    if (progress && progress->stopping &&
+        progress->stopping->load(std::memory_order_relaxed))
+        return 1;
+    if (progress && progress->callback && *progress->callback &&
+        downloadTotal > 0)
+        (*progress->callback)(static_cast<uint64_t>(downloadNow),
+                              static_cast<uint64_t>(downloadTotal));
     return 0;
 }
 
@@ -131,7 +144,8 @@ bool configureCurl(CURL* curl, const std::string& url, TransferKind kind,
 }
 
 bool fetchText(const std::string& url, size_t limit, std::string& body,
-               std::string& error) {
+               std::string& error,
+               const std::atomic<bool>* stopping = nullptr) {
     body.clear();
     CURL* curl = curl_easy_init();
     if (!configureCurl(curl, url, TransferKind::Metadata, error))
@@ -143,6 +157,10 @@ bool fetchText(const std::string& url, size_t limit, std::string& body,
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeString);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buffer);
+    TransferProgress progress{nullptr, stopping};
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, reportTransferProgress);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &progress);
     CURLcode result = curl_easy_perform(curl);
     long status = 0;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
@@ -163,7 +181,8 @@ bool fetchText(const std::string& url, size_t limit, std::string& body,
 
 bool fetchFile(const std::string& url, const std::string& path, size_t limit,
                std::string& error,
-               const UpdateService::ProgressCallback* progress = nullptr) {
+               const UpdateService::ProgressCallback* callback = nullptr,
+               const std::atomic<bool>* stopping = nullptr) {
     FileWriter writer;
     writer.output.open(path, std::ios::binary | std::ios::trunc);
     writer.limit = limit;
@@ -178,13 +197,10 @@ bool fetchFile(const std::string& url, const std::string& path, size_t limit,
     }
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeFile);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &writer);
-    if (progress) {
-        curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-        curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION,
-                         reportTransferProgress);
-        curl_easy_setopt(curl, CURLOPT_XFERINFODATA,
-                         const_cast<UpdateService::ProgressCallback*>(progress));
-    }
+    TransferProgress progress{callback, stopping};
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, reportTransferProgress);
+    curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &progress);
     CURLcode result = curl_easy_perform(curl);
     long status = 0;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
@@ -225,8 +241,15 @@ bool retryableFetchError(const std::string& error) {
 }
 
 template <typename Fetch>
-bool fetchWithRetry(Fetch fetch, std::string& error) {
+bool fetchWithRetry(Fetch fetch, std::string& error,
+                    const std::atomic<bool>& stopping,
+                    std::mutex& stopMutex,
+                    std::condition_variable& stopReady) {
     for (int attempt = 1; attempt <= kFetchAttempts; ++attempt) {
+        if (stopping.load(std::memory_order_relaxed)) {
+            error = "Update cancelled.";
+            return false;
+        }
         error.clear();
         if (fetch())
             return true;
@@ -236,7 +259,14 @@ bool fetchWithRetry(Fetch fetch, std::string& error) {
                 error += " (after " + std::to_string(attempt) + " attempts).";
             return false;
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(500 * attempt));
+        std::unique_lock<std::mutex> lock(stopMutex);
+        if (stopReady.wait_for(lock, std::chrono::milliseconds(500 * attempt),
+                               [&stopping] {
+                                   return stopping.load(std::memory_order_relaxed);
+                               })) {
+            error = "Update cancelled.";
+            return false;
+        }
     }
     return false;
 }
@@ -349,23 +379,44 @@ bool copyFileContents(const std::string& source, const std::string& destination,
 
 UpdateService::UpdateService(std::string targetPath,
                              MetadataFetcher metadataFetcher,
-                             AssetFetcher assetFetcher)
+                             AssetFetcher assetFetcher,
+                             std::string helperSourcePath)
     : targetPath_(std::move(targetPath)),
+      helperPath_([this] {
+          const size_t slash = targetPath_.find_last_of('/');
+          return targetPath_.substr(0, slash == std::string::npos ? 0 : slash + 1) +
+                 "pipensx-updater.nro";
+      }()),
+      helperSourcePath_(std::move(helperSourcePath)),
       metadataFetcher_(std::move(metadataFetcher)),
       assetFetcher_(std::move(assetFetcher)) {
     if (!metadataFetcher_)
-        metadataFetcher_ = fetchText;
+        metadataFetcher_ = [this](const std::string& url, size_t limit,
+                                  std::string& body, std::string& error) {
+            return fetchText(url, limit, body, error, &stopping_);
+        };
     if (!assetFetcher_)
         assetFetcher_ = [this](const std::string& url, const std::string& path,
                                size_t limit, std::string& error) {
-            return fetchFile(url, path, limit, error, &progress_);
+            return fetchFile(url, path, limit, error, &progress_, &stopping_);
         };
 }
 
 UpdateService::~UpdateService() {
+    shutdown();
+}
+
+void UpdateService::cancel() {
+    stopping_.store(true, std::memory_order_relaxed);
+    stopReady_.notify_all();
+}
+
+void UpdateService::shutdown() {
+    cancel();
     for (std::thread& worker : workers_)
         if (worker.joinable())
             worker.join();
+    workers_.clear();
 }
 
 bool UpdateService::isNewerVersion(const std::string& candidate,
@@ -422,7 +473,7 @@ UpdateCheckResult UpdateService::check() const {
     if (!fetchWithRetry([&] {
             return metadataFetcher_(kLatestReleaseUrl, kMetadataLimit, body,
                                     result.error);
-        }, result.error))
+        }, result.error, stopping_, stopMutex_, stopReady_))
         return result;
     if (!parseRelease(body, result.release, result.error))
         return result;
@@ -442,7 +493,7 @@ bool UpdateService::install(const ReleaseInfo& release, std::string& error) cons
     if (!fetchWithRetry([&] {
             return metadataFetcher_(release.checksumUrl, kChecksumLimit,
                                     checksumText, error);
-        }, error))
+        }, error, stopping_, stopMutex_, stopReady_))
         return false;
     std::string expectedChecksum;
     if (!parseChecksum(checksumText, expectedChecksum)) {
@@ -452,12 +503,13 @@ bool UpdateService::install(const ReleaseInfo& release, std::string& error) cons
     const std::string temporary = stagedPath();
     const std::string marker = temporary + ".sha256";
     const std::string helper = helperPath();
+    const std::string helperTemporary = helper + ".tmp";
     unlink(temporary.c_str());
     unlink(marker.c_str());
-    unlink(helper.c_str());
+    unlink(helperTemporary.c_str());
     if (!fetchWithRetry([&] {
             return assetFetcher_(release.nroUrl, temporary, kNroLimit, error);
-        }, error))
+        }, error, stopping_, stopMutex_, stopReady_))
         return false;
     std::string actualChecksum;
     if (!checksumFile(temporary, actualChecksum, error)) {
@@ -480,77 +532,42 @@ bool UpdateService::install(const ReleaseInfo& release, std::string& error) cons
     }
     markerFile.close();
     std::string helperError;
-    if (!copyFileContents(targetPath_, helper, helperError)) {
-        unlink(helper.c_str());
+    if (!copyFileContents(helperSourcePath_, helperTemporary, helperError)) {
+        unlink(helperTemporary.c_str());
         unlink(marker.c_str());
         unlink(temporary.c_str());
         error = "Unable to create update helper: " + helperError;
         return false;
     }
-    return true;
-}
-
-bool UpdateService::finalizeStaged(std::string& error) const {
-    const std::string temporary = stagedPath();
-    const std::string marker = temporary + ".sha256";
-    std::ifstream markerFile(marker, std::ios::binary);
-    std::ostringstream markerText;
-    markerText << markerFile.rdbuf();
-    std::string expectedChecksum;
-    if (!markerFile || !parseChecksum(markerText.str(), expectedChecksum)) {
-        error = "Staged update checksum is missing or invalid.";
+    std::string sourceHelperChecksum;
+    std::string copiedHelperChecksum;
+    if (!checksumFile(helperSourcePath_, sourceHelperChecksum, helperError) ||
+        !checksumFile(helperTemporary, copiedHelperChecksum, helperError) ||
+        sourceHelperChecksum != copiedHelperChecksum) {
+        if (helperError.empty())
+            helperError = "copied helper checksum does not match";
+        unlink(helperTemporary.c_str());
+        unlink(marker.c_str());
+        unlink(temporary.c_str());
+        error = "Unable to verify update helper: " + helperError;
         return false;
     }
-    std::string actualChecksum;
-    if (!checksumFile(temporary, actualChecksum, error))
-        return false;
-    if (actualChecksum != expectedChecksum) {
-        error = "Staged update checksum does not match.";
-        return false;
-    }
-
-    const std::string backup = targetPath_ + ".previous";
-    unlink(backup.c_str());
-    bool haveBackup = false;
-    if (access(targetPath_.c_str(), F_OK) == 0) {
-        if (rename(targetPath_.c_str(), backup.c_str()) == 0) {
-            haveBackup = true;
-        } else {
-            std::string backupError;
-            if (!copyFileContents(targetPath_, backup, backupError)) {
-                error = "Unable to back up current application: " +
-                        backupError;
-                return false;
-            }
-            haveBackup = true;
-        }
-    }
-
-    std::string copyError;
-    bool installed = copyFileContents(temporary, targetPath_, copyError);
-    if (installed) {
-        std::string installedChecksum;
-        installed = checksumFile(targetPath_, installedChecksum, copyError) &&
-                    installedChecksum == expectedChecksum;
-        if (!installed && copyError.empty())
-            copyError = "installed file checksum does not match";
-    }
-    if (!installed) {
-        unlink(targetPath_.c_str());
-        if (haveBackup) {
-            if (rename(backup.c_str(), targetPath_.c_str()) != 0) {
-                std::string ignored;
-                copyFileContents(backup, targetPath_, ignored);
-            }
-        }
-        error = "Unable to finalize staged update: " + copyError;
+    if (rename(helperTemporary.c_str(), helper.c_str()) != 0) {
+        helperError = std::strerror(errno);
+        unlink(helperTemporary.c_str());
+        unlink(marker.c_str());
+        unlink(temporary.c_str());
+        error = "Unable to publish update helper: " + helperError;
         return false;
     }
-
-    if (haveBackup)
-        unlink(backup.c_str());
-    unlink(marker.c_str());
-    unlink(temporary.c_str());
+#ifdef __SWITCH__
+    const Result commit = fsdevCommitDevice("sdmc");
+    if (R_FAILED(commit)) {
+        error = "Unable to commit staged update files.";
+        discardStaged();
+        return false;
+    }
+#endif
     return true;
 }
 
@@ -568,22 +585,40 @@ bool UpdateService::stagedReady() const {
            actualChecksum == expectedChecksum;
 }
 
+bool UpdateService::hasPendingConfirmation() const {
+    return access(backupPath().c_str(), F_OK) == 0 &&
+           access(stagedPath().c_str(), F_OK) != 0;
+}
+
+bool UpdateService::confirmInstalled(std::string& error) const {
+    const std::string staged = stagedPath();
+    const std::string marker = staged + ".sha256";
+    const std::string backup = backupPath();
+    update_paths_t paths{targetPath_.c_str(), staged.c_str(),
+                         marker.c_str(), backup.c_str()};
+    char transactionError[256] = {0};
+    if (!update_transaction_confirm(&paths, transactionError,
+                                    sizeof(transactionError))) {
+        error = transactionError;
+        return false;
+    }
+    unlink(helperPath_.c_str());
+#ifdef __SWITCH__
+    const Result commit = fsdevCommitDevice("sdmc");
+    if (R_FAILED(commit)) {
+        error = "Unable to commit update cleanup.";
+        return false;
+    }
+#endif
+    return true;
+}
+
 void UpdateService::discardStaged() const {
     const std::string temporary = stagedPath();
     unlink(temporary.c_str());
     unlink((temporary + ".sha256").c_str());
+    unlink((helperPath() + ".tmp").c_str());
     unlink(helperPath().c_str());
-}
-
-bool UpdateService::isStagedLaunch(
-        const std::vector<std::string>& arguments) const {
-    const std::string helper = helperPath();
-    for (const std::string& argument : arguments) {
-        if (argument == "--finish-update" ||
-            argument.find(helper) != std::string::npos)
-            return true;
-    }
-    return false;
 }
 
 void UpdateService::checkAsync(CheckCallback callback) {

--- a/src/app/update_service.hpp
+++ b/src/app/update_service.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -22,7 +25,7 @@ struct UpdateCheckResult {
 };
 
 // Retrieves published releases from the canonical GitHub repository. A
-// verified release is staged beside the active NRO, then a chain-loaded copy
+// verified release is staged beside the active NRO, then a minimal helper
 // finalizes the replacement after the original process has exited.
 class UpdateService {
 public:
@@ -36,7 +39,8 @@ public:
 
     explicit UpdateService(
         std::string targetPath = "sdmc:/switch/pipensx/pipensx.nro",
-        MetadataFetcher metadataFetcher = {}, AssetFetcher assetFetcher = {});
+        MetadataFetcher metadataFetcher = {}, AssetFetcher assetFetcher = {},
+        std::string helperSourcePath = "romfs:/pipensx-updater.nro");
     ~UpdateService();
 
     UpdateService(const UpdateService&) = delete;
@@ -44,15 +48,18 @@ public:
 
     UpdateCheckResult check() const;
     bool install(const ReleaseInfo& release, std::string& error) const;
-    bool finalizeStaged(std::string& error) const;
     bool stagedReady() const;
+    bool hasPendingConfirmation() const;
+    bool confirmInstalled(std::string& error) const;
     void discardStaged() const;
-    bool isStagedLaunch(const std::vector<std::string>& arguments) const;
     const std::string& targetPath() const { return targetPath_; }
     std::string stagedPath() const { return targetPath_ + ".update"; }
-    std::string helperPath() const { return targetPath_ + ".updater"; }
+    std::string backupPath() const { return targetPath_ + ".previous"; }
+    const std::string& helperPath() const { return helperPath_; }
     void checkAsync(CheckCallback callback);
     void installAsync(ReleaseInfo release, InstallCallback callback);
+    void cancel();
+    void shutdown();
     // Reports (received, total) from the built-in NRO downloader on a worker
     // thread. Set it before installAsync; the callback must marshal to the UI
     // thread itself.
@@ -67,10 +74,15 @@ public:
 
 private:
     std::string targetPath_;
+    std::string helperPath_;
+    std::string helperSourcePath_;
     MetadataFetcher metadataFetcher_;
     AssetFetcher assetFetcher_;
     ProgressCallback progress_;
     std::vector<std::thread> workers_;
+    mutable std::atomic<bool> stopping_{false};
+    mutable std::mutex stopMutex_;
+    mutable std::condition_variable stopReady_;
 };
 
 } // namespace pipensx

--- a/src/app/update_transaction.c
+++ b/src/app/update_transaction.c
@@ -1,0 +1,177 @@
+#include "update_transaction.h"
+
+#include "../core/sha256.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define UPDATE_NRO_LIMIT (64u * 1024u * 1024u)
+
+static void set_error(char *error, size_t size, const char *message) {
+    if (error && size)
+        snprintf(error, size, "%s", message ? message : "update failed");
+}
+
+static void set_errno_error(char *error, size_t size, const char *operation) {
+    if (error && size)
+        snprintf(error, size, "%s: %s", operation, strerror(errno));
+}
+
+static bool read_expected(const char *path, char expected[65],
+                          char *error, size_t error_size) {
+    FILE *file = fopen(path, "rb");
+    if (!file) {
+        set_errno_error(error, error_size, "Unable to open checksum marker");
+        return false;
+    }
+    char token[66] = {0};
+    const int matched = fscanf(file, "%65s", token);
+    fclose(file);
+    if (matched != 1 || strlen(token) != 64) {
+        set_error(error, error_size, "Staged update checksum is invalid");
+        return false;
+    }
+    for (size_t i = 0; i < 64; ++i) {
+        if (!isxdigit((unsigned char)token[i])) {
+            set_error(error, error_size, "Staged update checksum is invalid");
+            return false;
+        }
+        expected[i] = (char)tolower((unsigned char)token[i]);
+    }
+    expected[64] = '\0';
+    return true;
+}
+
+static bool checksum_file(const char *path, char actual[65],
+                          char *error, size_t error_size) {
+    struct stat info;
+    if (stat(path, &info) != 0) {
+        set_errno_error(error, error_size, "Unable to stat staged update");
+        return false;
+    }
+    if (info.st_size <= 0 || (uint64_t)info.st_size > UPDATE_NRO_LIMIT) {
+        set_error(error, error_size, "Staged update size is invalid");
+        return false;
+    }
+    FILE *file = fopen(path, "rb");
+    if (!file) {
+        set_errno_error(error, error_size, "Unable to open staged update");
+        return false;
+    }
+    const size_t size = (size_t)info.st_size;
+    uint8_t *data = malloc(size);
+    if (!data) {
+        fclose(file);
+        set_error(error, error_size, "Unable to allocate checksum buffer");
+        return false;
+    }
+    const bool read_ok = fread(data, 1, size, file) == size;
+    fclose(file);
+    if (!read_ok) {
+        free(data);
+        set_error(error, error_size, "Unable to read staged update");
+        return false;
+    }
+    uint8_t digest[32];
+    static const char digits[] = "0123456789abcdef";
+    sha256(data, size, digest);
+    free(data);
+    for (size_t i = 0; i < sizeof(digest); ++i) {
+        actual[i * 2] = digits[digest[i] >> 4];
+        actual[i * 2 + 1] = digits[digest[i] & 15];
+    }
+    actual[64] = '\0';
+    return true;
+}
+
+bool update_transaction_ready(const update_paths_t *paths,
+                              char *error, size_t error_size) {
+    char expected[65];
+    char actual[65];
+    if (!paths || !read_expected(paths->marker, expected, error, error_size) ||
+        !checksum_file(paths->staged, actual, error, error_size))
+        return false;
+    if (strcmp(expected, actual) != 0) {
+        set_error(error, error_size, "Staged update checksum does not match");
+        return false;
+    }
+    return true;
+}
+
+bool update_transaction_apply(const update_paths_t *paths,
+                              char *error, size_t error_size) {
+    if (!update_transaction_ready(paths, error, error_size))
+        return false;
+    unlink(paths->backup);
+    const bool had_target = access(paths->target, F_OK) == 0;
+    if (had_target && rename(paths->target, paths->backup) != 0) {
+        set_errno_error(error, error_size, "Unable to back up current NRO");
+        return false;
+    }
+    if (rename(paths->staged, paths->target) != 0) {
+        const int saved_errno = errno;
+        if (had_target)
+            rename(paths->backup, paths->target);
+        errno = saved_errno;
+        set_errno_error(error, error_size, "Unable to install staged NRO");
+        return false;
+    }
+    char expected[65];
+    char actual[65];
+    if (!read_expected(paths->marker, expected, error, error_size) ||
+        !checksum_file(paths->target, actual, error, error_size) ||
+        strcmp(expected, actual) != 0) {
+        update_transaction_rollback(paths, NULL, 0);
+        if (error && error_size && error[0] == '\0')
+            set_error(error, error_size, "Installed NRO checksum does not match");
+        return false;
+    }
+    return true;
+}
+
+bool update_transaction_rollback(const update_paths_t *paths,
+                                 char *error, size_t error_size) {
+    if (!paths || access(paths->backup, F_OK) != 0) {
+        set_error(error, error_size, "Update backup is missing");
+        return false;
+    }
+    unlink(paths->staged);
+    if (access(paths->target, F_OK) == 0 &&
+        rename(paths->target, paths->staged) != 0) {
+        set_errno_error(error, error_size, "Unable to restage failed NRO");
+        return false;
+    }
+    if (rename(paths->backup, paths->target) != 0) {
+        const int saved_errno = errno;
+        /* Keep at least one launchable NRO at the canonical path even when
+         * restoring the backup fails (for example after an SD I/O error). */
+        rename(paths->staged, paths->target);
+        errno = saved_errno;
+        set_errno_error(error, error_size, "Unable to restore previous NRO");
+        return false;
+    }
+    return true;
+}
+
+bool update_transaction_confirm(const update_paths_t *paths,
+                                char *error, size_t error_size) {
+    if (!paths) {
+        set_error(error, error_size, "Update paths are missing");
+        return false;
+    }
+    if (unlink(paths->backup) != 0 && errno != ENOENT) {
+        set_errno_error(error, error_size, "Unable to remove update backup");
+        return false;
+    }
+    if (unlink(paths->marker) != 0 && errno != ENOENT) {
+        set_errno_error(error, error_size, "Unable to remove checksum marker");
+        return false;
+    }
+    return true;
+}

--- a/src/app/update_transaction.h
+++ b/src/app/update_transaction.h
@@ -1,0 +1,31 @@
+#ifndef PIPENSX_UPDATE_TRANSACTION_H
+#define PIPENSX_UPDATE_TRANSACTION_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    const char *target;
+    const char *staged;
+    const char *marker;
+    const char *backup;
+} update_paths_t;
+
+bool update_transaction_ready(const update_paths_t *paths,
+                              char *error, size_t error_size);
+bool update_transaction_apply(const update_paths_t *paths,
+                              char *error, size_t error_size);
+bool update_transaction_rollback(const update_paths_t *paths,
+                                 char *error, size_t error_size);
+bool update_transaction_confirm(const update_paths_t *paths,
+                                char *error, size_t error_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/main_switch.cpp
+++ b/src/main_switch.cpp
@@ -128,36 +128,34 @@ int main(int argc, char** argv) {
     mkdir("sdmc:/switch/pipensx", 0755);
     log_init(LogPath);
 
-    std::vector<std::string> launchArguments;
-    for (int i = 0; i < argc; ++i)
-        if (argv[i])
-            launchArguments.emplace_back(argv[i]);
+    (void)argc;
+    (void)argv;
     UpdateService launchUpdater;
-    const bool stagedLaunch = launchUpdater.isStagedLaunch(launchArguments);
+    const bool updatePendingConfirmation =
+        launchUpdater.hasPendingConfirmation();
     // A verified download left behind by a session that quit before its
-    // restart also finalizes here, instead of being discarded below.
-    if (stagedLaunch || launchUpdater.stagedReady()) {
-        std::string error;
-        if (!launchUpdater.finalizeStaged(error)) {
-            diagnostic_error("update", "finalize", "error=%s",
-                             error.c_str());
-            if (stagedLaunch)
-                return 1;
-        } else {
-            const std::string target = launchUpdater.targetPath();
-            const Result result = envSetNextLoad(target.c_str(),
-                                                 target.c_str());
+    // restart must chain through the minimal updater, never overwrite the NRO
+    // that is currently executing.
+    if (launchUpdater.stagedReady()) {
+        if (envHasNextLoad() &&
+            access(launchUpdater.helperPath().c_str(), F_OK) == 0) {
+            const std::string helper = launchUpdater.helperPath();
+            const std::string arguments =
+                "\"" + helper + "\" --finish-update";
+            const Result result = envSetNextLoad(helper.c_str(),
+                                                 arguments.c_str());
             if (R_SUCCEEDED(result)) {
-                log_msg("[update] staged update finalized; relaunching\n");
+                log_msg("[update] staged update ready; launching helper\n");
                 log_close();
-                // Static destructors of never-initialized subsystems fault
-                // on this early-exit path; hbloader honors nextload without
-                // them.
-                std::_Exit(0);
+                return 0;
             }
-            diagnostic_error("update", "relaunch", "result=0x%08x", result);
-            if (stagedLaunch)
-                return 1;
+            diagnostic_error("update", "helper_nextload", "result=0x%08x",
+                             result);
+        } else {
+            diagnostic_error("update", "helper_missing",
+                             "nextload=%d helper=%d",
+                             envHasNextLoad() ? 1 : 0,
+                             access(launchUpdater.helperPath().c_str(), F_OK) == 0);
         }
     }
     AppSettings settings(SettingsPath, TelemetryFlagPath);
@@ -253,7 +251,6 @@ int main(int argc, char** argv) {
         metadata.setImageNetworkPaused(manager.hasActiveTransfer());
 
         UpdateService updater;
-        updater.discardStaged();
 
         startupStage("MainActivity construction");
         auto* activity = new MainActivity(&manager, &catalog, &metadata,
@@ -305,11 +302,20 @@ int main(int argc, char** argv) {
                 break;
             if (firstFrame) {
                 startupStage("main loop running");
+                if (updatePendingConfirmation) {
+                    std::string error;
+                    if (!launchUpdater.confirmInstalled(error))
+                        diagnostic_error("update", "confirm", "error=%s",
+                                         error.c_str());
+                    else
+                        log_msg("[update] installed update confirmed\n");
+                }
                 firstFrame = false;
             }
         }
 
         startupStage("manager shutdown");
+        updater.shutdown();
         manager.shutdown();
         performance.setActive(false);
     } catch (const std::exception& error) {
@@ -319,6 +325,7 @@ int main(int argc, char** argv) {
         log_msg("[crash] unknown exception\n");
     }
 
+    startupStage("app-owned teardown complete");
     startupStage("cleanup");
     if (esReady)
         esExit();
@@ -334,9 +341,5 @@ int main(int argc, char** argv) {
         gBorealisLog = nullptr;
     }
     log_close();
-    // Every durable side effect is already flushed above. Static destructors
-    // race exit-time unwind teardown on device (intermittent Data Abort in
-    // __deregister_frame_info_bases after quit), so leave without them; the
-    // loader still honors a pending envSetNextLoad.
-    std::_Exit(0);
+    return 0;
 }

--- a/src/ui/settings/settings_view.hpp
+++ b/src/ui/settings/settings_view.hpp
@@ -376,7 +376,8 @@ private:
                     return;
                 }
                 const std::string helper = updater_->helperPath();
-                const std::string arguments = helper + " --finish-update";
+                const std::string arguments =
+                    "\"" + helper + "\" --finish-update";
                 const Result result = envSetNextLoad(helper.c_str(),
                                                      arguments.c_str());
                 if (R_FAILED(result)) {

--- a/src/update_helper.c
+++ b/src/update_helper.c
@@ -1,0 +1,74 @@
+#include "app/update_transaction.h"
+
+#include <switch.h>
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+static const char *Target = "sdmc:/switch/pipensx/pipensx.nro";
+static const char *Staged = "sdmc:/switch/pipensx/pipensx.nro.update";
+static const char *Marker = "sdmc:/switch/pipensx/pipensx.nro.update.sha256";
+static const char *Backup = "sdmc:/switch/pipensx/pipensx.nro.previous";
+static const char *LogPath = "sdmc:/switch/pipensx/pipensx-update.log";
+
+static void update_log(const char *format, ...) {
+    FILE *file = fopen(LogPath, "ab");
+    if (!file)
+        return;
+    va_list args;
+    va_start(args, format);
+    vfprintf(file, format, args);
+    va_end(args);
+    fflush(file);
+    fclose(file);
+}
+
+static void return_to_target(void) {
+    char arguments[512];
+    snprintf(arguments, sizeof(arguments), "\"%s\"", Target);
+    Result result = envSetNextLoad(Target, arguments);
+    update_log("[helper] nextload target result=0x%08x\n", result);
+}
+
+int main(int argc, char **argv) {
+    update_paths_t paths = {Target, Staged, Marker, Backup};
+    char error[256] = {0};
+    const bool requested = argc > 1 && argv[1] &&
+                           strcmp(argv[1], "--finish-update") == 0;
+    update_log("[helper] started requested=%d nextload=%d\n",
+               requested ? 1 : 0, envHasNextLoad() ? 1 : 0);
+    if (!requested || !envHasNextLoad()) {
+        return_to_target();
+        return 0;
+    }
+    if (!update_transaction_apply(&paths, error, sizeof(error))) {
+        update_log("[helper] apply failed: %s\n", error);
+        return_to_target();
+        return 0;
+    }
+    Result commit = fsdevCommitDevice("sdmc");
+    if (R_FAILED(commit)) {
+        update_log("[helper] commit failed result=0x%08x\n", commit);
+        error[0] = '\0';
+        if (!update_transaction_rollback(&paths, error, sizeof(error)))
+            update_log("[helper] rollback failed: %s\n", error);
+        fsdevCommitDevice("sdmc");
+        return_to_target();
+        return 0;
+    }
+    char arguments[512];
+    snprintf(arguments, sizeof(arguments), "\"%s\"", Target);
+    Result next = envSetNextLoad(Target, arguments);
+    if (R_FAILED(next)) {
+        update_log("[helper] nextload failed result=0x%08x\n", next);
+        error[0] = '\0';
+        if (!update_transaction_rollback(&paths, error, sizeof(error)))
+            update_log("[helper] rollback failed: %s\n", error);
+        fsdevCommitDevice("sdmc");
+        return_to_target();
+        return 0;
+    }
+    update_log("[helper] swap committed; launching target\n");
+    return 0;
+}

--- a/tests/test_update_service.cpp
+++ b/tests/test_update_service.cpp
@@ -1,22 +1,33 @@
 #include "app/update_service.hpp"
 
 #include <cassert>
+#include <atomic>
+#include <chrono>
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <string>
+#include <thread>
 #include <unistd.h>
 
 namespace {
 
 constexpr const char* Target = "/tmp/pipensx-update-test.nro";
+constexpr const char* HelperSource = "/tmp/pipensx-updater-fixture.nro";
 
 bool emulateSwitchRename = false;
+bool failHelperPublish = false;
 
 extern "C" int __real_rename(const char* oldPath, const char* newPath);
 
 extern "C" int __wrap_rename(const char* oldPath, const char* newPath) {
+    if (failHelperPublish &&
+        std::strcmp(oldPath, "/tmp/pipensx-updater.nro.tmp") == 0 &&
+        std::strcmp(newPath, "/tmp/pipensx-updater.nro") == 0) {
+        errno = EIO;
+        return -1;
+    }
     if (emulateSwitchRename) {
         if (std::strcmp(oldPath, Target) == 0) {
             errno = EACCES;
@@ -59,22 +70,13 @@ void testVersionsAndReleaseValidation() {
                                                  release, error));
 }
 
-void testStagedLaunchDetectionUsesExecutablePath() {
-    pipensx::UpdateService service(Target);
-    assert(service.isStagedLaunch({service.helperPath()}));
-    assert(service.isStagedLaunch({
-        service.helperPath() + " --finish-update"}));
-    assert(service.isStagedLaunch({Target, "--finish-update"}));
-    assert(!service.isStagedLaunch({service.stagedPath()}));
-    assert(!service.isStagedLaunch({Target}));
-}
-
 void testStagedReadyRecoversInterruptedRestart() {
     unlink(Target);
     unlink("/tmp/pipensx-update-test.nro.update");
     unlink("/tmp/pipensx-update-test.nro.update.sha256");
-    unlink("/tmp/pipensx-update-test.nro.updater");
+    unlink("/tmp/pipensx-updater.nro");
     write(Target, "old");
+    write(HelperSource, "minimal updater helper");
     const std::string payload = "new verified pipensx nro";
     const std::string checksum =
         "9dc1034a694baa2d68b032ed446fbc9b170975306c571202e99ff741821365b4";
@@ -82,7 +84,8 @@ void testStagedReadyRecoversInterruptedRestart() {
         [checksum](const std::string&, size_t, std::string& body,
                    std::string&) { body = checksum + "  pipensx.nro\n"; return true; },
         [payload](const std::string&, const std::string& path, size_t,
-                  std::string&) { write(path, payload); return true; });
+                  std::string&) { write(path, payload); return true; },
+        HelperSource);
     assert(!service.stagedReady());
     pipensx::ReleaseInfo release{"v1.2.3",
         "https://github.com/i3sey/pipensx/releases/download/v1.2.3/pipensx.nro",
@@ -96,12 +99,6 @@ void testStagedReadyRecoversInterruptedRestart() {
     assert(!service.stagedReady());
     write("/tmp/pipensx-update-test.nro.update", payload);
     assert(service.stagedReady());
-    assert(service.finalizeStaged(error));
-    assert(!service.stagedReady());
-    std::ifstream finalized(Target, std::ios::binary);
-    std::string bytes((std::istreambuf_iterator<char>(finalized)), {});
-    assert(bytes == payload);
-    finalized.close();
     service.discardStaged();
     unlink(Target);
 }
@@ -110,8 +107,9 @@ void testInstallVerifiesBeforeStaging() {
     unlink(Target);
     unlink("/tmp/pipensx-update-test.nro.update");
     unlink("/tmp/pipensx-update-test.nro.update.sha256");
-    unlink("/tmp/pipensx-update-test.nro.updater");
+    unlink("/tmp/pipensx-updater.nro");
     write(Target, "old");
+    write(HelperSource, "minimal updater helper");
     const std::string payload = "new verified pipensx nro";
     const std::string checksum =
         "9dc1034a694baa2d68b032ed446fbc9b170975306c571202e99ff741821365b4";
@@ -119,7 +117,8 @@ void testInstallVerifiesBeforeStaging() {
         [checksum](const std::string&, size_t, std::string& body,
                    std::string&) { body = checksum + "  pipensx.nro\n"; return true; },
         [payload](const std::string&, const std::string& path, size_t,
-                  std::string&) { write(path, payload); return true; });
+                  std::string&) { write(path, payload); return true; },
+        HelperSource);
     pipensx::ReleaseInfo release{"v1.2.3",
         "https://github.com/i3sey/pipensx/releases/download/v1.2.3/pipensx.nro",
         "https://github.com/i3sey/pipensx/releases/download/v1.2.3/pipensx.nro.sha256"};
@@ -137,16 +136,12 @@ void testInstallVerifiesBeforeStaging() {
     assert(bytes == checksum + "\n");
     std::ifstream helper(service.helperPath(), std::ios::binary);
     bytes.assign((std::istreambuf_iterator<char>(helper)), {});
-    assert(bytes == "old");
+    assert(service.helperPath() == "/tmp/pipensx-updater.nro");
+    assert(bytes == "minimal updater helper");
     installed.close();
     current.close();
     marker.close();
     helper.close();
-    assert(service.finalizeStaged(error));
-    std::ifstream finalized(Target, std::ios::binary);
-    bytes.assign((std::istreambuf_iterator<char>(finalized)), {});
-    assert(bytes == payload);
-    finalized.close();
     service.discardStaged();
     assert(access("/tmp/pipensx-update-test.nro.update", F_OK) != 0);
     assert(access(service.helperPath().c_str(), F_OK) != 0);
@@ -156,7 +151,8 @@ void testInstallVerifiesBeforeStaging() {
         [](const std::string&, size_t, std::string& body,
            std::string&) { body = "0000000000000000000000000000000000000000000000000000000000000000\n"; return true; },
         [payload](const std::string&, const std::string& path, size_t,
-                  std::string&) { write(path, payload); return true; });
+                  std::string&) { write(path, payload); return true; },
+        HelperSource);
     assert(!wrongChecksum.install(release, error));
     std::ifstream preserved(Target, std::ios::binary);
     bytes.assign((std::istreambuf_iterator<char>(preserved)), {});
@@ -164,8 +160,9 @@ void testInstallVerifiesBeforeStaging() {
     unlink(Target);
     unlink("/tmp/pipensx-update-test.nro.update");
     unlink("/tmp/pipensx-update-test.nro.update.sha256");
-    unlink("/tmp/pipensx-update-test.nro.updater");
+    unlink("/tmp/pipensx-updater.nro");
     unlink("/tmp/pipensx-update-test.nro.update.sha256");
+    unlink(HelperSource);
 }
 
 void testTransientNetworkFailuresAreRetried() {
@@ -188,6 +185,7 @@ void testTransientNetworkFailuresAreRetried() {
     unlink(Target);
     unlink("/tmp/pipensx-update-test.nro.update");
     write(Target, "old");
+    write(HelperSource, "minimal updater helper");
     const std::string payload = "new verified pipensx nro";
     const std::string checksum =
         "9dc1034a694baa2d68b032ed446fbc9b170975306c571202e99ff741821365b4";
@@ -215,7 +213,7 @@ void testTransientNetworkFailuresAreRetried() {
             }
             write(path, payload);
             return true;
-        });
+        }, HelperSource);
     pipensx::ReleaseInfo release{"v9.9.9",
         "https://github.com/i3sey/pipensx/releases/download/v9.9.9/pipensx.nro",
         "https://github.com/i3sey/pipensx/releases/download/v9.9.9/pipensx.nro.sha256"};
@@ -231,9 +229,10 @@ void testInstallNeverTouchesRunningNro() {
     unlink(Target);
     unlink("/tmp/pipensx-update-test.nro.update");
     unlink("/tmp/pipensx-update-test.nro.update.sha256");
-    unlink("/tmp/pipensx-update-test.nro.updater");
+    unlink("/tmp/pipensx-updater.nro");
     unlink("/tmp/pipensx-update-test.nro.previous");
     write(Target, "old");
+    write(HelperSource, "minimal updater helper");
     const std::string payload = "new verified pipensx nro";
     const std::string checksum =
         "9dc1034a694baa2d68b032ed446fbc9b170975306c571202e99ff741821365b4";
@@ -241,7 +240,8 @@ void testInstallNeverTouchesRunningNro() {
         [checksum](const std::string&, size_t, std::string& body,
                    std::string&) { body = checksum + "  pipensx.nro\n"; return true; },
         [payload](const std::string&, const std::string& path, size_t,
-                  std::string&) { write(path, payload); return true; });
+                  std::string&) { write(path, payload); return true; },
+        HelperSource);
     pipensx::ReleaseInfo release{"v1.2.3",
         "https://github.com/i3sey/pipensx/releases/download/v1.2.3/pipensx.nro",
         "https://github.com/i3sey/pipensx/releases/download/v1.2.3/pipensx.nro.sha256"};
@@ -260,19 +260,77 @@ void testInstallNeverTouchesRunningNro() {
     unlink(Target);
     unlink("/tmp/pipensx-update-test.nro.update");
     unlink("/tmp/pipensx-update-test.nro.update.sha256");
-    unlink("/tmp/pipensx-update-test.nro.updater");
+    unlink("/tmp/pipensx-updater.nro");
     unlink("/tmp/pipensx-update-test.nro.previous");
+}
+
+void testShutdownInterruptsRetryWait() {
+    std::atomic<int> attempts{0};
+    pipensx::UpdateService service(Target,
+        [&attempts](const std::string&, size_t, std::string&,
+                    std::string& error) {
+            ++attempts;
+            error = "Update network error: Timeout was reached";
+            return false;
+        });
+    service.checkAsync([](pipensx::UpdateCheckResult) {});
+    while (attempts.load() == 0)
+        std::this_thread::yield();
+    const auto started = std::chrono::steady_clock::now();
+    service.shutdown();
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - started);
+    assert(elapsed.count() < 250);
+    assert(attempts.load() == 1);
+}
+
+void testHelperPublishFailurePreservesPreviousHelper() {
+    unlink(Target);
+    unlink("/tmp/pipensx-update-test.nro.update");
+    unlink("/tmp/pipensx-update-test.nro.update.sha256");
+    unlink("/tmp/pipensx-updater.nro.tmp");
+    write(Target, "old");
+    write(HelperSource, "new minimal updater helper");
+    write("/tmp/pipensx-updater.nro", "previous helper");
+    const std::string payload = "new verified pipensx nro";
+    const std::string checksum =
+        "9dc1034a694baa2d68b032ed446fbc9b170975306c571202e99ff741821365b4";
+    pipensx::UpdateService service(Target,
+        [checksum](const std::string&, size_t, std::string& body,
+                   std::string&) { body = checksum + "  pipensx.nro\n"; return true; },
+        [payload](const std::string&, const std::string& path, size_t,
+                  std::string&) { write(path, payload); return true; },
+        HelperSource);
+    pipensx::ReleaseInfo release{"v1.2.3",
+        "https://github.com/i3sey/pipensx/releases/download/v1.2.3/pipensx.nro",
+        "https://github.com/i3sey/pipensx/releases/download/v1.2.3/pipensx.nro.sha256"};
+    std::string error;
+    failHelperPublish = true;
+    const bool installed = service.install(release, error);
+    failHelperPublish = false;
+    assert(!installed);
+    assert(error.find("Unable to publish update helper") != std::string::npos);
+    std::ifstream helper(service.helperPath(), std::ios::binary);
+    std::string bytes((std::istreambuf_iterator<char>(helper)), {});
+    assert(bytes == "previous helper");
+    assert(access("/tmp/pipensx-updater.nro.tmp", F_OK) != 0);
+    assert(access("/tmp/pipensx-update-test.nro.update", F_OK) != 0);
+    assert(access("/tmp/pipensx-update-test.nro.update.sha256", F_OK) != 0);
+    unlink(Target);
+    unlink(service.helperPath().c_str());
+    unlink(HelperSource);
 }
 
 } // namespace
 
 int main() {
     testVersionsAndReleaseValidation();
-    testStagedLaunchDetectionUsesExecutablePath();
     testStagedReadyRecoversInterruptedRestart();
     testInstallVerifiesBeforeStaging();
     testTransientNetworkFailuresAreRetried();
     testInstallNeverTouchesRunningNro();
+    testShutdownInterruptsRetryWait();
+    testHelperPublishFailurePreservesPreviousHelper();
     std::puts("update service tests passed");
     return 0;
 }

--- a/tests/test_update_transaction.c
+++ b/tests/test_update_transaction.c
@@ -1,0 +1,166 @@
+#include "app/update_transaction.h"
+#include "core/sha256.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char *Root = "/tmp/pipensx-update-transaction";
+static const char *FailBackup = NULL;
+static const char *FailTarget = NULL;
+
+int __real_rename(const char *old_path, const char *new_path);
+
+int __wrap_rename(const char *old_path, const char *new_path) {
+    if (FailBackup && FailTarget && strcmp(old_path, FailBackup) == 0 &&
+        strcmp(new_path, FailTarget) == 0) {
+        errno = EIO;
+        return -1;
+    }
+    return __real_rename(old_path, new_path);
+}
+
+static void write_file(const char *path, const void *data, size_t size) {
+    FILE *file = fopen(path, "wb");
+    assert(file);
+    assert(fwrite(data, 1, size, file) == size);
+    assert(fclose(file) == 0);
+}
+
+static char *read_file(const char *path) {
+    FILE *file = fopen(path, "rb");
+    assert(file);
+    assert(fseek(file, 0, SEEK_END) == 0);
+    long size = ftell(file);
+    assert(size >= 0);
+    rewind(file);
+    char *data = calloc((size_t)size + 1, 1);
+    assert(data);
+    assert(fread(data, 1, (size_t)size, file) == (size_t)size);
+    assert(fclose(file) == 0);
+    return data;
+}
+
+static void write_marker(const char *path, const void *data, size_t size) {
+    uint8_t digest[32];
+    static const char digits[] = "0123456789abcdef";
+    char text[66];
+    sha256(data, size, digest);
+    for (size_t i = 0; i < sizeof(digest); ++i) {
+        text[i * 2] = digits[digest[i] >> 4];
+        text[i * 2 + 1] = digits[digest[i] & 15];
+    }
+    text[64] = '\n';
+    text[65] = '\0';
+    write_file(path, text, 65);
+}
+
+static void cleanup(const update_paths_t *paths) {
+    unlink(paths->target);
+    unlink(paths->staged);
+    unlink(paths->marker);
+    unlink(paths->backup);
+}
+
+static void test_apply_and_rollback(void) {
+    char target[256], staged[256], marker[256], backup[256];
+    snprintf(target, sizeof(target), "%s.nro", Root);
+    snprintf(staged, sizeof(staged), "%s.nro.update", Root);
+    snprintf(marker, sizeof(marker), "%s.nro.update.sha256", Root);
+    snprintf(backup, sizeof(backup), "%s.nro.previous", Root);
+    update_paths_t paths = {target, staged, marker, backup};
+    cleanup(&paths);
+
+    const char old_data[] = "old-version";
+    const char new_data[] = "new-version";
+    write_file(target, old_data, sizeof(old_data) - 1);
+    write_file(staged, new_data, sizeof(new_data) - 1);
+    write_marker(marker, new_data, sizeof(new_data) - 1);
+
+    char error[256] = {0};
+    assert(update_transaction_apply(&paths, error, sizeof(error)));
+    char *installed = read_file(target);
+    char *saved = read_file(backup);
+    assert(strcmp(installed, new_data) == 0);
+    assert(strcmp(saved, old_data) == 0);
+    assert(access(staged, F_OK) != 0);
+    free(installed);
+    free(saved);
+
+    assert(update_transaction_rollback(&paths, error, sizeof(error)));
+    char *restored = read_file(target);
+    char *restaged = read_file(staged);
+    assert(strcmp(restored, old_data) == 0);
+    assert(strcmp(restaged, new_data) == 0);
+    free(restored);
+    free(restaged);
+
+    assert(update_transaction_apply(&paths, error, sizeof(error)));
+    assert(update_transaction_confirm(&paths, error, sizeof(error)));
+    installed = read_file(target);
+    assert(strcmp(installed, new_data) == 0);
+    assert(access(backup, F_OK) != 0);
+    assert(access(marker, F_OK) != 0);
+    free(installed);
+    cleanup(&paths);
+}
+
+static void test_corrupt_stage_is_rejected(void) {
+    char target[256], staged[256], marker[256], backup[256];
+    snprintf(target, sizeof(target), "%s.nro", Root);
+    snprintf(staged, sizeof(staged), "%s.nro.update", Root);
+    snprintf(marker, sizeof(marker), "%s.nro.update.sha256", Root);
+    snprintf(backup, sizeof(backup), "%s.nro.previous", Root);
+    update_paths_t paths = {target, staged, marker, backup};
+    cleanup(&paths);
+    write_file(target, "old", 3);
+    write_file(staged, "expected", 8);
+    write_marker(marker, "expected", 8);
+    write_file(staged, "corrupt", 7);
+    char error[256] = {0};
+    assert(!update_transaction_apply(&paths, error, sizeof(error)));
+    char *preserved = read_file(target);
+    assert(strcmp(preserved, "old") == 0);
+    assert(access(backup, F_OK) != 0);
+    free(preserved);
+    cleanup(&paths);
+}
+
+static void test_rollback_restore_failure_keeps_canonical_target(void) {
+    char target[256], staged[256], marker[256], backup[256];
+    snprintf(target, sizeof(target), "%s.nro", Root);
+    snprintf(staged, sizeof(staged), "%s.nro.update", Root);
+    snprintf(marker, sizeof(marker), "%s.nro.update.sha256", Root);
+    snprintf(backup, sizeof(backup), "%s.nro.previous", Root);
+    update_paths_t paths = {target, staged, marker, backup};
+    cleanup(&paths);
+    write_file(target, "new-version", 11);
+    write_file(backup, "old-version", 11);
+
+    FailBackup = backup;
+    FailTarget = target;
+    char error[256] = {0};
+    assert(!update_transaction_rollback(&paths, error, sizeof(error)));
+    FailBackup = NULL;
+    FailTarget = NULL;
+
+    char *launchable = read_file(target);
+    char *preserved_backup = read_file(backup);
+    assert(strcmp(launchable, "new-version") == 0);
+    assert(strcmp(preserved_backup, "old-version") == 0);
+    assert(access(staged, F_OK) != 0);
+    free(launchable);
+    free(preserved_backup);
+    cleanup(&paths);
+}
+
+int main(void) {
+    test_apply_and_rollback();
+    test_corrupt_stage_is_rejected();
+    test_rollback_restore_failure_keeps_canonical_target();
+    puts("update transaction tests passed");
+    return 0;
+}


### PR DESCRIPTION
Rebased `peersmetadata` (previously local-only, 15 commits behind) onto current `main`.

Cancels app-owned workers before libnx teardown and replaces the running NRO
through an atomic helper, avoiding forwarder forced-shutdown errors. Adds
`update_transaction.{c,h}`, `update_helper.c` and a `test_update_transaction`
suite.

Conflicts were confined to `Makefile.pc`, where this branch predated the
web-seed test target and the `mse`/`-lcrypto` link change — resolved in favour
of main in all four hunks, keeping only the new `UPDATE_TRANSACTION_TEST_TARGET`
wiring from this branch.

Verified locally on the rebased tip:
- `make test` clean-room: all 17 test binaries + the Python suite pass,
  including the new `update transaction tests passed`
- `scripts/golden.sh check`: 16 screenshots + 2 behaviour screens pass
- `make -f Makefile.switch`: NRO builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)