### PR TITLE
fix(install): preserve resumable package journals

### DIFF
--- a/Makefile.pc
+++ b/Makefile.pc
@@ -79,6 +79,7 @@ BUDGET_ARBITER_TEST_TARGET = $(BUILD_DIR)/tests/test_budget_arbiter
 REQUEST_GATE_TEST_TARGET = $(BUILD_DIR)/tests/test_request_gate
 INSTALL_PACER_TEST_TARGET = $(BUILD_DIR)/tests/test_install_pacer
 JOURNAL_TEST_TARGET = $(BUILD_DIR)/tests/test_install_journal
+PACKAGE_COORDINATOR_TEST_TARGET = $(BUILD_DIR)/tests/test_package_coordinator
 WEB_SEED_TEST_TARGET = $(BUILD_DIR)/tests/test_web_seed
 MSE_TEST_TARGET = $(BUILD_DIR)/tests/test_mse
 DHT_CACHE_TEST_TARGET = $(BUILD_DIR)/tests/test_dht_cache
@@ -224,7 +225,7 @@ $(PACKAGE_TEST_TARGET): tests/test_package_stream.cpp \
 		$(BUILD_DIR)/src/install/package_stream.o $(BUILD_DIR)/src/install/install_backend_pc.o \
 		$(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
-	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(INSTALL_LDFLAGS) -pthread
+	$(CXX) $(CXXFLAGS) -Isrc -o $@ $(filter-out src/app/package_coordinator.hpp,$^) $(INSTALL_LDFLAGS) -pthread
 
 
 $(BUILD_DIR)/src/app/catalog_service.o: src/app/catalog_service.cpp
@@ -323,7 +324,8 @@ test: $(TEST_TARGET) $(MANAGER_TEST_TARGET) $(PACKAGE_TEST_TARGET) \
 		$(RAM_BUDGET_TEST_TARGET) $(BUDGET_ARBITER_TEST_TARGET) \
 		$(REQUEST_GATE_TEST_TARGET) \
 		$(INSTALL_PACER_TEST_TARGET) \
-		$(JOURNAL_TEST_TARGET) $(WEB_SEED_TEST_TARGET) \
+		$(JOURNAL_TEST_TARGET) $(PACKAGE_COORDINATOR_TEST_TARGET) \
+		$(WEB_SEED_TEST_TARGET) \
 		$(FAVORITES_TEST_TARGET) \
 		$(MSE_TEST_TARGET) $(DHT_CACHE_TEST_TARGET) \
 		$(DHT_SHARED_TEST_TARGET) \
@@ -354,6 +356,7 @@ test: $(TEST_TARGET) $(MANAGER_TEST_TARGET) $(PACKAGE_TEST_TARGET) \
 	./$(REQUEST_GATE_TEST_TARGET)
 	./$(INSTALL_PACER_TEST_TARGET)
 	./$(JOURNAL_TEST_TARGET)
+	./$(PACKAGE_COORDINATOR_TEST_TARGET)
 	./$(WEB_SEED_TEST_TARGET)
 	./$(FAVORITES_TEST_TARGET)
 	./$(MSE_TEST_TARGET)
@@ -457,6 +460,18 @@ $(JOURNAL_TEST_TARGET): tests/test_install_journal.cpp \
 		$(BUILD_DIR)/src/install/install_journal.o $(BUILD_DIR)/src/core/bencode.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
+
+$(PACKAGE_COORDINATOR_TEST_TARGET): tests/test_package_coordinator.cpp \
+		$(BUILD_DIR)/src/app/stream_ram_budget.o $(BUILD_DIR)/src/app/stream_budget_arbiter.o \
+		$(BUILD_DIR)/src/app/request_gate.o $(BUILD_DIR)/src/app/install_pacer.o \
+		$(BUILD_DIR)/src/install/package_stream.o $(BUILD_DIR)/src/install/install_journal.o \
+		$(BUILD_DIR)/src/install/install_backend_pc.o $(BUILD_DIR)/src/core/bencode.o \
+		$(BUILD_DIR)/src/core/metainfo.o $(BUILD_DIR)/src/core/sha1.o \
+		$(BUILD_DIR)/src/core/util.o
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) -Isrc -o $@ $(filter-out src/app/package_coordinator.hpp,$^) $(INSTALL_LDFLAGS) -pthread
+
+$(PACKAGE_COORDINATOR_TEST_TARGET): src/app/package_coordinator.hpp
 
 $(WEB_SEED_TEST_TARGET): tests/test_web_seed.cpp $(BUILD_DIR)/src/app/web_seed_source.o \
 		$(BUILD_DIR)/src/core/util.o

--- a/src/app/download_manager.cpp
+++ b/src/app/download_manager.cpp
@@ -1883,6 +1883,8 @@ void DownloadManager::runTask(RunnerSlot* slot, ClaimedTask claim) {
                 task->status = DownloadStatus::Error;
                 task->error = !installError.empty()
                     ? installError : torrent_last_error(torrent);
+                if (coordinator && installError.empty())
+                    coordinator->markRecoverableError(task->error);
                 task->speedBytesPerSecond = 0;
             }
         }

--- a/src/app/package_coordinator.hpp
+++ b/src/app/package_coordinator.hpp
@@ -188,7 +188,8 @@ public:
         // F-B: an interruption with a journaled safe point keeps the partial
         // install on disk for a later resume; anything else rolls back and
         // drops the journal.
-        if (journalValid_ && !abandonResume_ && error().empty()) {
+        if (journalValid_ && !abandonResume_ &&
+            (error().empty() || recoverableError_.load())) {
             backend_->suspendPackage();
             return;
         }
@@ -199,6 +200,14 @@ public:
 
     // The task is going away: never keep partial data or the journal.
     void abandonResume() { abandonResume_ = true; }
+
+    // The package stream is intact, but the transfer source failed (peer loss,
+    // timeout, disconnect). Keep the journal/placeholder safe point so retry
+    // resumes instead of re-streaming the package from byte zero.
+    void markRecoverableError(const std::string& message) {
+        std::lock_guard<std::mutex> lock(queueMutex_);
+        setErrorLocked(message, true);
+    }
 
     const std::vector<storage_file_config_t>& configs() const {
         return configs_;
@@ -395,7 +404,7 @@ private:
 
         PendingKey key {ordinal, offset};
         if (pending_.find(key) != pending_.end())
-            return setErrorLocked("Duplicate package stream chunk.");
+            return setErrorLocked("Duplicate package stream chunk.", false);
         // Never wait for buffer space here (PERF_PLAN 5.3): this runs inside
         // the torrent thread's piece callback, so blocking would stall the
         // whole event loop. Chunks already in flight are always accepted —
@@ -747,12 +756,16 @@ private:
 
     bool setError(const std::string& message) {
         std::lock_guard<std::mutex> lock(queueMutex_);
-        return setErrorLocked(message);
+        return setErrorLocked(message, false);
     }
 
-    bool setErrorLocked(const std::string& message) {
+    bool setErrorLocked(const std::string& message, bool recoverable) {
+        if (!recoverable)
+            recoverableError_.store(false);
         if (error_.empty()) {
             error_ = message.empty() ? "Installation pipeline failed." : message;
+            if (recoverable)
+                recoverableError_.store(true);
             log_msg("[install] pipeline error: %s\n", error_.c_str());
         }
         accepting_ = false;
@@ -933,7 +946,7 @@ private:
                 producerOffset_ = 0;
                 ++producerOrdinal_;
             } else if (producerOffset_ >= static_cast<uint64_t>(file.length)) {
-                setErrorLocked("Package stream missed final chunk.");
+                setErrorLocked("Package stream missed final chunk.", false);
                 break;
             }
         }
@@ -1007,6 +1020,7 @@ private:
     uint64_t journalConsumed_ = 0;
     bool journalValid_ = false;
     bool abandonResume_ = false;
+    std::atomic<bool> recoverableError_{false};
     bool streamInstall_ = false;
     std::vector<storage_file_config_t> configs_;
     std::vector<uint32_t> pieceOrder_;

--- a/tests/test_package_coordinator.cpp
+++ b/tests/test_package_coordinator.cpp
@@ -1,0 +1,149 @@
+#include "app/package_coordinator.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+void append32(std::vector<uint8_t>& out, uint32_t value) {
+    for (unsigned i = 0; i < 4; ++i)
+        out.push_back(static_cast<uint8_t>(value >> (i * 8)));
+}
+
+void append64(std::vector<uint8_t>& out, uint64_t value) {
+    for (unsigned i = 0; i < 8; ++i)
+        out.push_back(static_cast<uint8_t>(value >> (i * 8)));
+}
+
+std::vector<uint8_t> makePfs0(const std::string& name,
+                              const std::vector<uint8_t>& file) {
+    std::vector<uint8_t> out{'P', 'F', 'S', '0'};
+    append32(out, 1);
+    append32(out, static_cast<uint32_t>(name.size() + 1));
+    append32(out, 0);
+    append64(out, 0);
+    append64(out, file.size());
+    append32(out, 0);
+    append32(out, 0);
+    out.insert(out.end(), name.begin(), name.end());
+    out.push_back(0);
+    out.insert(out.end(), file.begin(), file.end());
+    return out;
+}
+
+metainfo_t makeSingleFileMetainfo(const std::string& name, uint64_t size) {
+    metainfo_t mi{};
+    std::snprintf(mi.name, sizeof(mi.name), "%s", name.c_str());
+    mi.piece_length = 4 * 1024 * 1024;
+    mi.total_length = static_cast<int64_t>(size);
+    mi.num_pieces = static_cast<uint32_t>(
+        (size + static_cast<uint64_t>(mi.piece_length) - 1) /
+        static_cast<uint64_t>(mi.piece_length));
+    mi.piece_hashes = static_cast<uint8_t*>(std::calloc(mi.num_pieces, 20));
+    assert(mi.piece_hashes);
+    mi.num_files = 1;
+    mi.files = static_cast<mi_file_t*>(std::calloc(1, sizeof(mi_file_t)));
+    assert(mi.files);
+    std::snprintf(mi.files[0].path, sizeof(mi.files[0].path), "%s",
+                  name.c_str());
+    mi.files[0].length = static_cast<int64_t>(size);
+    mi.files[0].offset = 0;
+    return mi;
+}
+
+bool feedRange(pipensx::PackageCoordinator& coordinator,
+               const std::vector<uint8_t>& data, uint64_t offset,
+               uint64_t end) {
+    const auto& config = coordinator.configs()[0];
+    const size_t chunkSize = 1024 * 1024;
+    while (offset < end) {
+        size_t n = static_cast<size_t>(std::min<uint64_t>(chunkSize,
+                                                          end - offset));
+        if (!config.sink(config.user, 0, static_cast<int64_t>(offset),
+                         data.data() + offset, n))
+            return false;
+        offset += n;
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    const std::string root = "/tmp/pipensx-package-coordinator-test";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+
+    std::vector<uint8_t> nca(40 * 1024 * 1024, 0x5a);
+    for (size_t i = 0; i < nca.size(); ++i)
+        nca[i] = static_cast<uint8_t>(i * 17 + 3);
+    std::vector<uint8_t> nsp = makePfs0(
+        "00112233445566778899aabbccddeeff.nca", nca);
+
+    metainfo_t mi = makeSingleFileMetainfo("game.nsp", nsp.size());
+    const std::string taskId = "00112233445566778899aabbccddeeff00112233";
+    const std::string journalPath = pipensx::installJournalPath(root, taskId);
+
+    pipensx::install::InstallJournal saved;
+    {
+        pipensx::StreamBudgetArbiter arbiter;
+        pipensx::PackageCoordinator coordinator(
+            mi, taskId, root, true, {}, 0,
+            pipensx::install::InstallStorageTarget::SdCard,
+            arbiter, nullptr);
+        assert(coordinator.error().empty());
+        assert(coordinator.configs().size() == 1);
+        assert(coordinator.configs()[0].mode == STORAGE_FILE_SINK);
+
+        // Feed beyond the 32 MiB checkpoint interval, then simulate a torrent
+        // network failure. The recoverable error must preserve the journal and
+        // partial backend output instead of rolling back.
+        assert(feedRange(coordinator, nsp, 0, 36ull * 1024 * 1024));
+        bool journalLoaded = false;
+        for (int spins = 0; spins < 3000; ++spins) {
+            if (pipensx::install::loadInstallJournal(journalPath, saved)) {
+                journalLoaded = true;
+                break;
+            }
+            usleep(10000);
+        }
+        assert(journalLoaded);
+        assert(saved.state.consumed > 0);
+        coordinator.markRecoverableError("peer connection timed out");
+    }
+
+    assert(pipensx::install::loadInstallJournal(journalPath, saved));
+    assert(saved.state.consumed > 0);
+    uint64_t resumeOffset = saved.state.consumed;
+
+    {
+        pipensx::StreamBudgetArbiter arbiter;
+        pipensx::PackageCoordinator coordinator(
+            mi, taskId, root, true, {}, 0,
+            pipensx::install::InstallStorageTarget::SdCard,
+            arbiter, nullptr);
+        assert(coordinator.error().empty());
+        assert(coordinator.configs()[0].ready_bytes == resumeOffset);
+        assert(feedRange(coordinator, nsp, resumeOffset, nsp.size()));
+        assert(coordinator.finish());
+    }
+
+    struct stat st{};
+    std::string committed = root + "/install-sim/" + taskId + "-game.nsp";
+    assert(stat(committed.c_str(), &st) == 0);
+    assert(!pipensx::install::loadInstallJournal(journalPath, saved));
+
+    metainfo_free(&mi);
+    std::filesystem::remove_all(root);
+    puts("package coordinator tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Preserve install journals when package streaming stops because the transfer source fails, allowing retries to resume from the last checkpoint instead of re-streaming from byte zero.
- Keep fatal package/stream errors on the rollback path so corrupt or incomplete installs do not leave stale journal state.
- Add a PC package coordinator regression test covering checkpoint preservation, resume, completion, and journal cleanup.

Closes #15

## Verification
- `rtk git diff --check`
- `unset PKG_CONFIG_LIBDIR PKG_CONFIG_PATH && rtk make -f Makefile.pc build-pc/tests/test_package_coordinator build-pc/tests/test_package_stream build-pc/tests/test_debrid_transfer && rtk build-pc/tests/test_package_coordinator && rtk build-pc/tests/test_package_stream && rtk build-pc/tests/test_debrid_transfer`
- `rtk make switch` produced `build-switch/pipensx.nro` (14321965 bytes)
- `unset PKG_CONFIG_LIBDIR PKG_CONFIG_PATH && rtk make -f Makefile.pc test` fails in existing `test_manager` case at `tests/test_manager.cpp:763` (`assert(armed)`) after earlier tests pass; this matches the pre-existing webseeds=0 failure observed before this change.