### PR TITLE
fix(downloads): keep removing tasks visible

### DIFF
--- a/scripts/golden.sh
+++ b/scripts/golden.sh
@@ -27,7 +27,7 @@ SCREENS="${GOLDEN_SCREENS:-catalog detail frame downloads download-files deploy-
 # baseline, so they are never compared against tests/golden/. Entries are
 # <screen> or <screen>:<locale>; hints-budget runs in both because Russian hint
 # labels are ~20% wider than English and are what actually overruns the bar.
-BEHAVIOR_SCREENS="${GOLDEN_BEHAVIOR_SCREENS:-downloads-back torrent-selection-scroll hints-budget hints-budget:ru bug-report-focus first-run-focus first-run-focus:ru sidebar-touch detail-rail-nav catalog-header-clearance update-chooser-toggle first-run-disclaimer installed-bundles}"
+BEHAVIOR_SCREENS="${GOLDEN_BEHAVIOR_SCREENS:-downloads-back downloads-removing torrent-selection-scroll hints-budget hints-budget:ru bug-report-focus first-run-focus first-run-focus:ru sidebar-touch detail-rail-nav catalog-header-clearance update-chooser-toggle first-run-disclaimer installed-bundles}"
 THEMES="${GOLDEN_THEMES:-light dark}"
 # frame is in the list because it is the only screen that renders the nav
 # sidebar, whose 248px width (theme.hpp installSidebarStyle) is the

--- a/src/ui/downloads/downloads_view.cpp
+++ b/src/ui/downloads/downloads_view.cpp
@@ -17,7 +17,8 @@ void DownloadDataSource::setTasks(std::vector<DownloadTask> tasks,
                    s == DownloadStatus::Downloading ||
                    s == DownloadStatus::Installing ||
                    s == DownloadStatus::Committing ||
-                   s == DownloadStatus::Verifying;
+                   s == DownloadStatus::Verifying ||
+                   s == DownloadStatus::Removing;
         }},
         {tr("pipensx/downloads/section_queue"), [](DownloadStatus s) {
             return s == DownloadStatus::Queued;

--- a/src/ui/downloads/downloads_view.hpp
+++ b/src/ui/downloads/downloads_view.hpp
@@ -185,7 +185,7 @@ public:
                     startRefreshing(true);
                 });
         }
-        if (!leased)
+        if (!leased && task.status != DownloadStatus::Removing)
             add(tr("pipensx/common/remove"),
                     [this, taskId] { openRemoveDialog(taskId); });
 

--- a/tools/golden_runner.cpp
+++ b/tools/golden_runner.cpp
@@ -17,8 +17,8 @@
 //                          bug-report-detail|bug-report-focus|sidebar-touch
 //                 [--frames N] [--sandbox <dir>]
 //
-// downloads-back, torrent-selection-scroll, hints-budget, bug-report-focus,
-// sidebar-touch, update-chooser-toggle, first-run-disclaimer and
+// downloads-back, downloads-removing, torrent-selection-scroll, hints-budget,
+// bug-report-focus, sidebar-touch, update-chooser-toggle, first-run-disclaimer and
 // installed-bundles are behaviour checks: they assert and exit non-zero
 // instead of producing a baseline.
 //
@@ -720,6 +720,24 @@ int main(int argc, char** argv) {
             tr("pipensx/nav/downloads"), NavIconType::Downloads,
             [downloadsView] { return downloadsView; });
         activity = new GoldenActivity(downloadsBackFrame);
+    } else if (screen == "downloads-removing") {
+        pipensx::DownloadTask removing;
+        removing.id = "removing-fixture";
+        removing.name = "Large package cleanup";
+        removing.status = pipensx::DownloadStatus::Removing;
+
+        DownloadDataSource source(nullptr);
+        source.setTasks({removing});
+        const pipensx::DownloadTask* row =
+            source.taskAt(brls::IndexPath(0, 0));
+        if (source.numberOfSections(nullptr) != 1 ||
+            source.numberOfRows(nullptr, 0) != 1 || !row ||
+            row->status != pipensx::DownloadStatus::Removing)
+            return fail("downloads-removing row is not visible");
+        std::printf("golden_runner: downloads-removing row visible\n");
+        manager.shutdown();
+        std::fflush(nullptr);
+        _exit(0);
     } else if (screen == "frame") {
         // Whole shell, same wiring as src/main_switch.cpp: covers the sidebar
         // and the storage footer docked at its bottom.


### PR DESCRIPTION
## Summary
- Keep `DownloadStatus::Removing` tasks in the downloads list by grouping them with active operations.
- Add a golden behavior check that asserts a Removing task still produces a visible data-source row.

Closes #16

## Verification
- `rtk git diff --check`
- `rm -rf build-golden && unset PKG_CONFIG_LIBDIR PKG_CONFIG_PATH && rtk cmake -S . -B build-golden -DPIPENSX_GOLDEN=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_IGNORE_PREFIX_PATH=/opt/devkitpro/portlibs/switch && rtk cmake --build build-golden --target golden_runner`
- `unset PKG_CONFIG_LIBDIR PKG_CONFIG_PATH && rtk make golden`
- `rtk make switch` produced `build-switch/pipensx.nro` (14321965 bytes)
- `unset PKG_CONFIG_LIBDIR PKG_CONFIG_PATH && rtk make -f Makefile.pc test` fails in existing `test_manager` case at `tests/test_manager.cpp:763` (`assert(armed)`) after earlier tests pass; this matches the pre-existing webseeds=0 failure observed before this change.