### PR TITLE
fix(tracker): retry UDP announces and gate started event

### DIFF
--- a/Makefile.pc
+++ b/Makefile.pc
@@ -65,6 +65,7 @@ PACKAGE_TEST_TARGET = $(BUILD_DIR)/tests/test_package_stream
 CATALOG_TEST_TARGET = $(BUILD_DIR)/tests/test_catalog
 TELEMETRY_TEST_TARGET = $(BUILD_DIR)/tests/test_telemetry
 PEER_TEST_TARGET = $(BUILD_DIR)/tests/test_peer
+TRACKER_TEST_TARGET = $(BUILD_DIR)/tests/test_tracker
 TORRENT_TEST_TARGET = $(BUILD_DIR)/tests/test_torrent
 SETTINGS_TEST_TARGET = $(BUILD_DIR)/tests/test_app_settings
 FAVORITES_TEST_TARGET = $(BUILD_DIR)/tests/test_favorites
@@ -315,7 +316,8 @@ $(PROBE_REPORT_TEST_TARGET): tests/test_probe_report.c src/probe/probe_report.c
 test: $(TEST_TARGET) $(MANAGER_TEST_TARGET) $(PACKAGE_TEST_TARGET) \
 		$(CATALOG_TEST_TARGET) \
 		$(TELEMETRY_TEST_TARGET) $(PEER_TEST_TARGET) \
-		$(TORRENT_TEST_TARGET) $(SETTINGS_TEST_TARGET) $(UPDATE_TEST_TARGET) \
+		$(TRACKER_TEST_TARGET) $(TORRENT_TEST_TARGET) \
+		$(SETTINGS_TEST_TARGET) $(UPDATE_TEST_TARGET) \
 		$(GAME_UPDATE_TEST_TARGET) \
 		$(UPDATE_FILE_SELECT_TEST_TARGET) \
 		$(UPDATE_TRANSACTION_TEST_TARGET) \
@@ -341,6 +343,7 @@ test: $(TEST_TARGET) $(MANAGER_TEST_TARGET) $(PACKAGE_TEST_TARGET) \
 	./$(CATALOG_TEST_TARGET)
 	./$(TELEMETRY_TEST_TARGET)
 	./$(PEER_TEST_TARGET)
+	./$(TRACKER_TEST_TARGET)
 	./$(TORRENT_TEST_TARGET)
 	./$(SETTINGS_TEST_TARGET)
 	./$(UPDATE_TEST_TARGET)
@@ -565,6 +568,12 @@ $(PEER_TEST_TARGET): tests/test_peer.c src/core/peer.c src/core/net.c \
 		$(UTP_OBJS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -Isrc -o $@ $^ $(LDFLAGS) -lstdc++ -Wl,--wrap=setsockopt
+
+$(TRACKER_TEST_TARGET): tests/test_tracker.c src/core/tracker.c \
+		src/core/bencode.c src/core/util.c src/core/net.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -Isrc -o $@ $(filter-out src/core/tracker.c,$^) \
+		$(LDFLAGS)
 
 # torrent.c is a real prerequisite (the test #includes it as source) but must
 # not be passed to the compiler a second time — hence the filter-out in $^.

--- a/src/core/torrent.c
+++ b/src/core/torrent.c
@@ -185,11 +185,12 @@ struct torrent {
     uint64_t last_tracker_ms;
     uint64_t last_connect_ms;
 
-    /* Async tracker announce: tracker_announce() blocks up to 5 s per tracker,
-       so it runs on a worker thread instead of freezing the event loop. The
-       loop launches a run (announce_start), keeps servicing peers, and drains
-       results on a later tick (announce_collect). async_ok is 0 only if the
-       mutex failed to init, in which case announces fall back to synchronous. */
+    /* Async tracker announce: tracker_announce() blocks on tracker/network
+       timeouts, so it runs on a worker thread instead of freezing the event
+       loop. The loop launches a run (announce_start), keeps servicing peers,
+       and drains results on a later tick (announce_collect). async_ok is 0
+       only if the mutex failed to init, in which case announces fall back to
+       synchronous. */
     pthread_t       announce_thread;
     pthread_mutex_t announce_mutex;
     int             async_ok;
@@ -199,6 +200,8 @@ struct torrent {
     uint8_t         announce_compact[200*6];
     int64_t         announce_downloaded;
     int64_t         announce_left;
+    int             announce_started_event;
+    int             tracker_started_event_sent;
     /* Set by torrent_destroy before it joins the announce thread, read by
        that thread between trackers and from curl's progress callback. */
     atomic_int      announce_stop;
@@ -1264,9 +1267,10 @@ static void *announce_worker(void *arg) {
     /* mi/peer_id/listen_port are immutable for the torrent's life;
        downloaded/left were snapshotted before the thread was launched. */
     uint8_t compact[200*6];
-    uint32_t n = tracker_announce(&t->mi, t->peer_id, t->listen_port,
-                                  t->announce_downloaded, t->announce_left,
-                                  compact, 200, announce_cancelled, t);
+    uint32_t n = tracker_announce_with_event(
+        &t->mi, t->peer_id, t->listen_port, t->announce_downloaded,
+        t->announce_left, compact, 200, t->announce_started_event,
+        announce_cancelled, t);
     pthread_mutex_lock(&t->announce_mutex);
     memcpy(t->announce_compact, compact, (size_t)n*6);
     t->announce_count = n;
@@ -1282,6 +1286,8 @@ static void announce_start(torrent_t *t, int64_t downloaded, int64_t left) {
         return;
     t->announce_downloaded = downloaded;
     t->announce_left       = left;
+    t->announce_started_event = !t->tracker_started_event_sent;
+    t->tracker_started_event_sent = 1;
     if (t->async_ok) {
         t->announce_done  = 0;
         t->announce_count = 0;
@@ -1292,9 +1298,9 @@ static void announce_start(torrent_t *t, int64_t downloaded, int64_t left) {
         log_msg("[torrent] announce thread spawn failed, running inline\n");
     }
     uint8_t compact[200*6];
-    uint32_t n = tracker_announce(&t->mi, t->peer_id, t->listen_port,
-                                  downloaded, left, compact, 200,
-                                  announce_cancelled, t);
+    uint32_t n = tracker_announce_with_event(
+        &t->mi, t->peer_id, t->listen_port, downloaded, left, compact, 200,
+        t->announce_started_event, announce_cancelled, t);
     announce_push_results(t, compact, n);
     log_msg("[torrent] announce (sync): %u peers\n", n);
 }

--- a/src/core/tracker.c
+++ b/src/core/tracker.c
@@ -66,6 +66,27 @@ static int curl_progress_cb(void *user, curl_off_t download_total,
     return tracker_cancelled((const tracker_cancel_t *)user);
 }
 
+static int http_build_announce_url(char *out, size_t outsz, const char *url,
+                                   const uint8_t *info_hash,
+                                   const uint8_t *peer_id,
+                                   uint16_t listen_port,
+                                   int64_t downloaded, int64_t left,
+                                   int started_event) {
+    char ih_enc[64], pid_enc[64];
+    url_encode_hash(ih_enc, sizeof(ih_enc), info_hash, 20);
+    url_encode_hash(pid_enc, sizeof(pid_enc), peer_id, 20);
+
+    int n = snprintf(out, outsz,
+                     "%s%cinfo_hash=%s&peer_id=%s&port=%u"
+                     "&uploaded=0&downloaded=%lld&left=%lld"
+                     "&compact=1%s&numwant=200",
+                     url, strchr(url, '?') ? '&' : '?', ih_enc, pid_enc,
+                     (unsigned)listen_port,
+                     (long long)downloaded, (long long)left,
+                     started_event ? "&event=started" : "");
+    return n >= 0 && (size_t)n < outsz;
+}
+
 static size_t curl_write_cb(void *ptr, size_t sz, size_t nmemb, void *ud) {
     curl_buf_t *b = (curl_buf_t*)ud;
     size_t total = sz * nmemb;
@@ -83,24 +104,18 @@ static uint32_t http_announce_once(const char *url,
                                    uint16_t listen_port,
                                    int64_t downloaded, int64_t left,
                                    uint8_t *compact_out, uint32_t max_peers,
+                                   int started_event,
                                    int *request_ok,
                                    tracker_announce_result_t *result,
                                    const tracker_cancel_t *cancel) {
     *request_ok = 0;
     if (tracker_cancelled(cancel))
         return 0;
-    char ih_enc[64], pid_enc[64];
-    url_encode_hash(ih_enc, sizeof(ih_enc), info_hash, 20);
-    url_encode_hash(pid_enc, sizeof(pid_enc), peer_id, 20);
-
     char full_url[1024];
-    snprintf(full_url, sizeof(full_url),
-             "%s%cinfo_hash=%s&peer_id=%s&port=%u"
-             "&uploaded=0&downloaded=%lld&left=%lld"
-             "&compact=1&event=started&numwant=200",
-             url, strchr(url, '?') ? '&' : '?', ih_enc, pid_enc,
-             (unsigned)listen_port,
-             (long long)downloaded, (long long)left);
+    if (!http_build_announce_url(full_url, sizeof(full_url), url, info_hash,
+                                 peer_id, listen_port, downloaded, left,
+                                 started_event))
+        return 0;
 
     CURL *curl = curl_easy_init();
     if (!curl) return 0;
@@ -192,18 +207,76 @@ static uint32_t http_announce(const char *url,
                               uint16_t listen_port,
                               int64_t downloaded, int64_t left,
                               uint8_t *compact_out, uint32_t max_peers,
+                              int started_event,
                               tracker_announce_result_t *result,
                               const tracker_cancel_t *cancel) {
     int request_ok = 0;
     return http_announce_once(url, info_hash, peer_id, listen_port,
                               downloaded, left, compact_out, max_peers,
-                              &request_ok, result, cancel);
+                              started_event, &request_ok, result, cancel);
 }
 
 /* ---- UDP tracker (BEP15) ---- */
 #define UDP_MAGIC  0x41727101980ULL
 #define UDP_CONNECT  0
 #define UDP_ANNOUNCE 1
+#ifndef UDP_RETRIES
+#define UDP_RETRIES 3
+#endif
+#ifndef UDP_RETRY_TIMEOUT_MS
+#define UDP_RETRY_TIMEOUT_MS 2500
+#endif
+
+static void wr64be(uint8_t *p, uint64_t v) {
+    p[0]=(v>>56)&0xFF; p[1]=(v>>48)&0xFF;
+    p[2]=(v>>40)&0xFF; p[3]=(v>>32)&0xFF;
+    p[4]=(v>>24)&0xFF; p[5]=(v>>16)&0xFF;
+    p[6]=(v>> 8)&0xFF; p[7]=(v    )&0xFF;
+}
+
+static void wr32be(uint8_t *p, uint32_t v) {
+    p[0]=(v>>24)&0xFF; p[1]=(v>>16)&0xFF;
+    p[2]=(v>> 8)&0xFF; p[3]=(v    )&0xFF;
+}
+
+static void udp_build_announce_packet(uint8_t ann[98], uint64_t conn_id,
+                                      uint32_t txid,
+                                      const uint8_t *info_hash,
+                                      const uint8_t *peer_id,
+                                      uint16_t listen_port,
+                                      int64_t downloaded, int64_t left,
+                                      int started_event) {
+    memset(ann, 0, 98);
+    wr64be(ann, conn_id);
+    wr32be(ann + 8, UDP_ANNOUNCE);
+    wr32be(ann + 12, txid);
+    memcpy(ann + 16, info_hash, 20);
+    memcpy(ann + 36, peer_id, 20);
+    wr64be(ann + 56, downloaded < 0 ? 0 : (uint64_t)downloaded);
+    wr64be(ann + 64, left < 0 ? 0 : (uint64_t)left);
+    wr32be(ann + 80, started_event ? 2u : 0u);
+    /* num_want: -1 lets the tracker choose its default. */
+    ann[92]=0xFF; ann[93]=0xFF; ann[94]=0xFF; ann[95]=0xFF;
+    ann[96]=(listen_port>>8)&0xFF; ann[97]=listen_port&0xFF;
+}
+
+static int udp_poll_read(socket_t fd, int timeout_ms,
+                         const tracker_cancel_t *cancel) {
+    int waited = 0;
+    while (waited < timeout_ms) {
+        if (tracker_cancelled(cancel))
+            return -1;
+        int slice = timeout_ms - waited;
+        if (slice > 100)
+            slice = 100;
+        struct pollfd pfd = { fd, POLLIN, 0 };
+        int rc = poll(&pfd, 1, slice);
+        if (rc != 0)
+            return rc;
+        waited += slice;
+    }
+    return 0;
+}
 
 /* BEP-15: every reply repeats the action and transaction_id of the request.
    Checking both, plus the source address, is what keeps an unsolicited
@@ -226,9 +299,12 @@ static uint32_t udp_announce(const char *host, uint16_t tport,
                              const uint8_t *info_hash,
                              const uint8_t *peer_id,
                              uint16_t listen_port,
-                             int64_t downloaded __attribute__((unused)),
-                             int64_t left __attribute__((unused)),
-                             uint8_t *compact_out, uint32_t max_peers) {
+                             int64_t downloaded, int64_t left,
+                             uint8_t *compact_out, uint32_t max_peers,
+                             int started_event,
+                             const tracker_cancel_t *cancel) {
+    if (tracker_cancelled(cancel))
+        return 0;
     struct sockaddr_in addr;
     if (!net_resolve(host, tport, &addr)) return 0;
 
@@ -251,23 +327,47 @@ static uint32_t udp_announce(const char *host, uint16_t tport,
     con_req[12]=(txid>>24)&0xFF; con_req[13]=(txid>>16)&0xFF;
     con_req[14]=(txid>> 8)&0xFF; con_req[15]=(txid    )&0xFF;
 
-    sendto(fd, con_req, 16, 0, (struct sockaddr*)&addr, sizeof(addr));
-
-    /* Wait for connect response */
-    struct pollfd pfd = { fd, POLLIN, 0 };
-    if (poll(&pfd, 1, 5000) <= 0) { net_close(fd); return 0; }
-
-    /* Read into a scratch address: passing &addr here let whoever answered
-       first replace the tracker we resolved, and the announce below then
-       went to them. */
     uint8_t con_resp[16];
     struct sockaddr_in from;
     socklen_t alen = sizeof(from);
-    if (recvfrom(fd, con_resp, 16, 0, (struct sockaddr*)&from, &alen) < 16) {
-        net_close(fd); return 0;
+
+    int connected = 0;
+    for (int attempt = 1; attempt <= UDP_RETRIES; ++attempt) {
+        if (tracker_cancelled(cancel)) {
+            log_msg("[tracker] UDP %s:%u: cancelled during connect\n",
+                    host, tport);
+            net_close(fd); return 0;
+        }
+        sendto(fd, con_req, 16, 0, (struct sockaddr*)&addr, sizeof(addr));
+        int poll_rc = udp_poll_read(fd, UDP_RETRY_TIMEOUT_MS, cancel);
+        if (poll_rc <= 0) {
+            if (poll_rc < 0) {
+                log_msg("[tracker] UDP %s:%u: cancelled during connect\n",
+                        host, tport);
+                net_close(fd); return 0;
+            }
+            log_msg("[tracker] UDP %s:%u: connect timeout (%d/%d)\n",
+                    host, tport, attempt, UDP_RETRIES);
+            continue;
+        }
+
+        /* Read into a scratch address: passing &addr here let whoever answered
+           first replace the tracker we resolved, and the announce below then
+           went to them. */
+        alen = sizeof(from);
+        if (recvfrom(fd, con_resp, 16, 0, (struct sockaddr*)&from, &alen) < 16) {
+            log_msg("[tracker] UDP %s:%u: short connect reply (%d/%d)\n",
+                    host, tport, attempt, UDP_RETRIES);
+            continue;
+        }
+        if (!udp_reply_matches(con_resp, UDP_CONNECT, txid, &addr, &from)) {
+            log_msg("[tracker] UDP %s:%u: bogus connect reply\n", host, tport);
+            net_close(fd); return 0;
+        }
+        connected = 1;
+        break;
     }
-    if (!udp_reply_matches(con_resp, UDP_CONNECT, txid, &addr, &from)) {
-        log_msg("[tracker] UDP %s:%u: bogus connect reply\n", host, tport);
+    if (!connected) {
         net_close(fd); return 0;
     }
     uint64_t conn_id =((uint64_t)con_resp[8]<<56)|((uint64_t)con_resp[9]<<48)|
@@ -277,40 +377,51 @@ static uint32_t udp_announce(const char *host, uint16_t tport,
 
     /* Announce phase */
     uint8_t ann[98];
-    memset(ann, 0, sizeof(ann));
-    ann[0]=(conn_id>>56)&0xFF; ann[1]=(conn_id>>48)&0xFF;
-    ann[2]=(conn_id>>40)&0xFF; ann[3]=(conn_id>>32)&0xFF;
-    ann[4]=(conn_id>>24)&0xFF; ann[5]=(conn_id>>16)&0xFF;
-    ann[6]=(conn_id>> 8)&0xFF; ann[7]=(conn_id    )&0xFF;
-    ann[8]=ann[9]=ann[10]=0; ann[11]=UDP_ANNOUNCE;
     txid++;
-    ann[12]=(txid>>24)&0xFF; ann[13]=(txid>>16)&0xFF;
-    ann[14]=(txid>> 8)&0xFF; ann[15]=(txid    )&0xFF;
-    memcpy(ann+16, info_hash, 20);
-    memcpy(ann+36, peer_id,   20);
-    /* downloaded / left / uploaded: 8 bytes each */
-    /* event=2 (started) at offset 80 */
-    ann[83] = 2; /* event started */
-    /* num_want: -1 = 200 */
-    ann[92]=0xFF; ann[93]=0xFF; ann[94]=0xFF; ann[95]=0xFF;
-    ann[96]=(listen_port>>8)&0xFF; ann[97]=listen_port&0xFF;
-
-    sendto(fd, ann, 98, 0, (struct sockaddr*)&addr, sizeof(addr));
-
-    /* Wait for announce response */
-    if (poll(&pfd, 1, 5000) <= 0) { net_close(fd); return 0; }
+    udp_build_announce_packet(ann, conn_id, txid, info_hash, peer_id,
+                              listen_port, downloaded, left, started_event);
 
     uint8_t resp[1500];
-    alen = sizeof(from);
-    ssize_t rlen = recvfrom(fd, resp, sizeof(resp), 0,
-                            (struct sockaddr*)&from, &alen);
+    ssize_t rlen = 0;
+    int announced = 0;
+    for (int attempt = 1; attempt <= UDP_RETRIES; ++attempt) {
+        if (tracker_cancelled(cancel)) {
+            log_msg("[tracker] UDP %s:%u: cancelled during announce\n",
+                    host, tport);
+            net_close(fd); return 0;
+        }
+        sendto(fd, ann, 98, 0, (struct sockaddr*)&addr, sizeof(addr));
+        int poll_rc = udp_poll_read(fd, UDP_RETRY_TIMEOUT_MS, cancel);
+        if (poll_rc <= 0) {
+            if (poll_rc < 0) {
+                log_msg("[tracker] UDP %s:%u: cancelled during announce\n",
+                        host, tport);
+                net_close(fd); return 0;
+            }
+            log_msg("[tracker] UDP %s:%u: announce timeout (%d/%d)\n",
+                    host, tport, attempt, UDP_RETRIES);
+            continue;
+        }
+
+        alen = sizeof(from);
+        rlen = recvfrom(fd, resp, sizeof(resp), 0,
+                        (struct sockaddr*)&from, &alen);
+        if (rlen < 20) {
+            log_msg("[tracker] UDP %s:%u: short announce reply (%d/%d)\n",
+                    host, tport, attempt, UDP_RETRIES);
+            continue;
+        }
+        if (!udp_reply_matches(resp, UDP_ANNOUNCE, txid, &addr, &from)) {
+            log_msg("[tracker] UDP %s:%u: bogus announce reply\n", host, tport);
+            net_close(fd); return 0;
+        }
+        announced = 1;
+        break;
+    }
     net_close(fd);
 
-    if (rlen < 20) return 0;
-    if (!udp_reply_matches(resp, UDP_ANNOUNCE, txid, &addr, &from)) {
-        log_msg("[tracker] UDP %s:%u: bogus announce reply\n", host, tport);
+    if (!announced)
         return 0;
-    }
     uint32_t count = (uint32_t)((rlen - 20) / 6);
     if (count > max_peers) count = max_peers;
     memcpy(compact_out, resp + 20, count * 6);
@@ -319,6 +430,13 @@ static uint32_t udp_announce(const char *host, uint16_t tport,
 }
 
 /* ---- public API ---- */
+static uint32_t tracker_announce_url_ex_cancel_event(
+    const char *url, const uint8_t *info_hash, const uint8_t *peer_id,
+    uint16_t listen_port, int64_t downloaded, int64_t left,
+    uint8_t *compact_out, uint32_t max_peers,
+    tracker_announce_result_t *result, int started_event,
+    tracker_cancel_cb cancel_callback, void *cancel_user);
+
 uint32_t tracker_announce_url_ex(const char *url,
                                  const uint8_t *info_hash,
                                  const uint8_t *peer_id,
@@ -341,6 +459,22 @@ uint32_t tracker_announce_url_ex_cancel(
                                  tracker_announce_result_t *result,
                                  tracker_cancel_cb cancel_callback,
                                  void *cancel_user) {
+    return tracker_announce_url_ex_cancel_event(
+        url, info_hash, peer_id, listen_port, downloaded, left, compact_out,
+        max_peers, result, 1, cancel_callback, cancel_user);
+}
+
+static uint32_t tracker_announce_url_ex_cancel_event(
+                                 const char *url,
+                                 const uint8_t *info_hash,
+                                 const uint8_t *peer_id,
+                                 uint16_t listen_port,
+                                 int64_t downloaded, int64_t left,
+                                 uint8_t *compact_out, uint32_t max_peers,
+                                 tracker_announce_result_t *result,
+                                 int started_event,
+                                 tracker_cancel_cb cancel_callback,
+                                 void *cancel_user) {
     tracker_result_init(result);
     if (!url || !info_hash || !peer_id || !compact_out || !max_peers)
         return 0;
@@ -351,7 +485,7 @@ uint32_t tracker_announce_url_ex_cancel(
     if (strncmp(url, "http", 4) == 0) {
         count = http_announce(url, info_hash, peer_id, listen_port,
                               downloaded, left, compact_out, max_peers,
-                              result, &cancel);
+                              started_event, result, &cancel);
         if (result)
             result->peers = count;
         return count;
@@ -362,7 +496,8 @@ uint32_t tracker_announce_url_ex_cancel(
         if (sscanf(url + 6, "%127[^:/]:%hu", host, &port) < 1)
             return 0;
         count = udp_announce(host, port, info_hash, peer_id, listen_port,
-                             downloaded, left, compact_out, max_peers);
+                             downloaded, left, compact_out, max_peers,
+                             started_event, &cancel);
         if (result)
             result->peers = count;
         return count;
@@ -387,6 +522,18 @@ uint32_t tracker_announce(const metainfo_t *mi,
                           int64_t downloaded, int64_t left,
                           uint8_t *compact_out, uint32_t max_peers,
                           tracker_cancel_cb cancel, void *cancel_user) {
+    return tracker_announce_with_event(mi, peer_id, listen_port, downloaded,
+                                       left, compact_out, max_peers, 1,
+                                       cancel, cancel_user);
+}
+
+uint32_t tracker_announce_with_event(const metainfo_t *mi,
+                          const uint8_t *peer_id,
+                          uint16_t listen_port,
+                          int64_t downloaded, int64_t left,
+                          uint8_t *compact_out, uint32_t max_peers,
+                          int started_event,
+                          tracker_cancel_cb cancel, void *cancel_user) {
     uint32_t total = 0;
     uint8_t tmp[200*6];
 
@@ -401,9 +548,9 @@ uint32_t tracker_announce(const metainfo_t *mi,
         const char *url = mi->trackers[t];
         uint32_t n = 0;
 
-        n = tracker_announce_url_ex_cancel(url, mi->info_hash, peer_id,
-                                           listen_port, downloaded, left, tmp,
-                                           200, NULL, cancel, cancel_user);
+        n = tracker_announce_url_ex_cancel_event(
+            url, mi->info_hash, peer_id, listen_port, downloaded, left, tmp,
+            200, NULL, started_event, cancel, cancel_user);
 
         uint32_t can = (total + n <= max_peers) ? n : max_peers - total;
         memcpy(compact_out + total*6, tmp, can*6);
@@ -411,4 +558,3 @@ uint32_t tracker_announce(const metainfo_t *mi,
     }
     return total;
 }
-

--- a/src/core/tracker.h
+++ b/src/core/tracker.h
@@ -24,6 +24,17 @@ uint32_t tracker_announce(const metainfo_t *mi,
                           tracker_cancel_cb cancel,
                           void          *cancel_user);
 
+uint32_t tracker_announce_with_event(const metainfo_t *mi,
+                                     const uint8_t *peer_id,
+                                     uint16_t       listen_port,
+                                     int64_t        downloaded,
+                                     int64_t        left,
+                                     uint8_t       *compact_out,
+                                     uint32_t       max_peers,
+                                     int started_event,
+                                     tracker_cancel_cb cancel,
+                                     void          *cancel_user);
+
 /*
  * Announce a bare info hash to one tracker. This is used while resolving a
  * magnet, before a metainfo dictionary exists.

--- a/tests/test_torrent.c
+++ b/tests/test_torrent.c
@@ -440,6 +440,19 @@ static void test_initial_peers_keep_verified_order(void) {
     assert(ip == laterIp && port == laterPort && no_mse == 0 && use_utp == 1);
 }
 
+static void test_started_event_only_on_first_announce(void) {
+    torrent_t torrent = {0};
+
+    /* No trackers keeps this lifecycle test local and network-free. */
+    announce_start(&torrent, 0, 1);
+    assert(torrent.announce_started_event == 1);
+    assert(torrent.tracker_started_event_sent == 1);
+
+    announce_start(&torrent, 0, 1);
+    assert(torrent.announce_started_event == 0);
+    assert(torrent.tracker_started_event_sent == 1);
+}
+
 int main(void) {
     test_ema_update();
     test_last_piece_age_marks_missing_sample();
@@ -451,6 +464,7 @@ int main(void) {
     test_copy_have_bitfield_guards();
     test_blocklist_cooldown_and_wrap();
     test_initial_peers_keep_verified_order();
+    test_started_event_only_on_first_announce();
     test_bencode_rejects_deep_nesting();
     test_metainfo_path_join_bounds();
     test_metainfo_rejects_bad_numbers();

--- a/tests/test_tracker.c
+++ b/tests/test_tracker.c
@@ -1,0 +1,166 @@
+#include <assert.h>
+#include <arpa/inet.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#define UDP_RETRY_TIMEOUT_MS 100
+#include "../src/core/tracker.c"
+
+static uint32_t rd32be(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
+           ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
+
+static uint64_t rd64be(const uint8_t *p) {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; ++i)
+        v = (v << 8) | p[i];
+    return v;
+}
+
+static void test_http_started_event_only_when_requested(void) {
+    uint8_t info_hash[20];
+    uint8_t peer_id[20];
+    memset(info_hash, 0x11, sizeof(info_hash));
+    memset(peer_id, 0x22, sizeof(peer_id));
+
+    char url[1024];
+    assert(http_build_announce_url(url, sizeof(url),
+                                   "http://tracker.example/announce",
+                                   info_hash, peer_id, 51413, 123, 456, 1));
+    assert(strstr(url, "&event=started") != NULL);
+
+    assert(http_build_announce_url(url, sizeof(url),
+                                   "http://tracker.example/announce",
+                                   info_hash, peer_id, 51413, 123, 456, 0));
+    assert(strstr(url, "event=started") == NULL);
+    assert(strstr(url, "&numwant=200") != NULL);
+}
+
+static void test_udp_started_event_only_when_requested(void) {
+    uint8_t info_hash[20];
+    uint8_t peer_id[20];
+    uint8_t ann[98];
+    memset(info_hash, 0x33, sizeof(info_hash));
+    memset(peer_id, 0x44, sizeof(peer_id));
+
+    udp_build_announce_packet(ann, 0x0102030405060708ULL, 0x0a0b0c0d,
+                              info_hash, peer_id, 51413, 123, 456, 1);
+    assert(rd32be(ann + 80) == 2);
+    assert(rd64be(ann + 56) == 123);
+    assert(rd64be(ann + 64) == 456);
+
+    udp_build_announce_packet(ann, 0x0102030405060708ULL, 0x0a0b0c0d,
+                              info_hash, peer_id, 51413, 123, 456, 0);
+    assert(rd32be(ann + 80) == 0);
+}
+
+struct retry_udp_tracker {
+    int fd;
+    uint16_t port;
+    int drop_connect;
+    int drop_announce;
+    int connect_requests;
+    int announce_requests;
+};
+
+static void *retry_udp_tracker_run(void *arg) {
+    struct retry_udp_tracker *s = arg;
+    uint8_t req[128], resp[26];
+    struct sockaddr_in peer;
+    socklen_t plen = sizeof(peer);
+
+    for (;;) {
+        ssize_t n = recvfrom(s->fd, req, sizeof(req), 0,
+                             (struct sockaddr *)&peer, &plen);
+        if (n < 16)
+            return NULL;
+        assert(rd32be(req + 8) == UDP_CONNECT);
+        s->connect_requests++;
+        if (s->connect_requests <= s->drop_connect)
+            continue;
+        memset(resp, 0, sizeof(resp));
+        wr32be(resp, UDP_CONNECT);
+        wr32be(resp + 4, rd32be(req + 12));
+        memset(resp + 8, 0xAB, 8);
+        sendto(s->fd, resp, 16, 0, (struct sockaddr *)&peer, plen);
+        break;
+    }
+
+    for (;;) {
+        plen = sizeof(peer);
+        ssize_t n = recvfrom(s->fd, req, sizeof(req), 0,
+                             (struct sockaddr *)&peer, &plen);
+        if (n < 16)
+            return NULL;
+        assert(rd32be(req + 8) == UDP_ANNOUNCE);
+        s->announce_requests++;
+        if (s->announce_requests <= s->drop_announce)
+            continue;
+        memset(resp, 0, sizeof(resp));
+        wr32be(resp, UDP_ANNOUNCE);
+        wr32be(resp + 4, rd32be(req + 12));
+        resp[20] = 1; resp[21] = 2; resp[22] = 3; resp[23] = 4;
+        resp[24] = 0x16; resp[25] = 0x2E;
+        sendto(s->fd, resp, 26, 0, (struct sockaddr *)&peer, plen);
+        return NULL;
+    }
+}
+
+static uint32_t announce_against_retry_fake(int drop_connect,
+                                            int drop_announce,
+                                            struct retry_udp_tracker *s) {
+    memset(s, 0, sizeof(*s));
+    s->fd = socket(AF_INET, SOCK_DGRAM, 0);
+    assert(s->fd >= 0);
+    s->drop_connect = drop_connect;
+    s->drop_announce = drop_announce;
+    struct timeval timeout = {2, 0};
+    assert(setsockopt(s->fd, SOL_SOCKET, SO_RCVTIMEO, &timeout,
+                      sizeof(timeout)) == 0);
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    assert(bind(s->fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    socklen_t alen = sizeof(addr);
+    assert(getsockname(s->fd, (struct sockaddr *)&addr, &alen) == 0);
+    s->port = ntohs(addr.sin_port);
+
+    pthread_t th;
+    assert(pthread_create(&th, NULL, retry_udp_tracker_run, s) == 0);
+
+    char url[64];
+    snprintf(url, sizeof(url), "udp://127.0.0.1:%u", (unsigned)s->port);
+    uint8_t info_hash[20], peer_id[20], compact[6 * 8];
+    memset(info_hash, 0x11, sizeof(info_hash));
+    memset(peer_id, 0x22, sizeof(peer_id));
+    uint32_t got = tracker_announce_url_ex_cancel_event(
+        url, info_hash, peer_id, 51413, 0, 100, compact, 8, NULL, 1,
+        NULL, NULL);
+
+    pthread_join(th, NULL);
+    close(s->fd);
+    return got;
+}
+
+static void test_udp_retries_dropped_datagrams(void) {
+    struct retry_udp_tracker s;
+    assert(announce_against_retry_fake(1, 1, &s) == 1);
+    assert(s.connect_requests == 2);
+    assert(s.announce_requests == 2);
+}
+
+int main(void) {
+    test_http_started_event_only_when_requested();
+    test_udp_started_event_only_when_requested();
+    test_udp_retries_dropped_datagrams();
+    puts("tracker tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Retries UDP tracker connect and announce requests before giving up, with timeout logging for dropped packets.
- Sends the tracker `event=started` parameter only for the first torrent announce, then suppresses it on later announces.
- Adds focused tracker tests for HTTP/UDP started-event encoding and UDP retry behavior.

Closes #17.

## Verification
- `rtk git diff --check`
- `unset PKG_CONFIG_LIBDIR PKG_CONFIG_PATH && rtk make pc`
- `unset PKG_CONFIG_LIBDIR PKG_CONFIG_PATH && rtk make -f Makefile.pc build-pc/tests/test_tracker build-pc/tests/test_torrent && rtk build-pc/tests/test_tracker && rtk build-pc/tests/test_torrent`
- `unset PKG_CONFIG_LIBDIR PKG_CONFIG_PATH && rtk make -f Makefile.pc test` fails only at the known pre-existing `test_manager` assertion: `tests/test_manager.cpp:763: int main(): Assertion 'armed' failed.`