### PR TITLE
feat(ui): animated busy indicators for long operations

### DIFF
--- a/src/ui/catalog/catalog_view.hpp
+++ b/src/ui/catalog/catalog_view.hpp
@@ -26,6 +26,7 @@
 #include "ui/catalog/catalog_grid.hpp"
 #include "ui/catalog/catalog_helpers.hpp"
 #include "ui/i18n.hpp"
+#include "ui/common/busy_pulse.hpp"
 #include "ui/common/message_cells.hpp"
 #include "ui/common/ui_helpers.hpp"
 #include "ui/detail/game_detail.hpp"
@@ -262,6 +263,17 @@ public:
         freshnessSpacer->setGrow(1.0f);
         freshnessSpacer->setFocusable(false);
         freshnessRow_->addView(freshnessSpacer);
+        // Pulsing dot while a refresh/batch resolve is in flight — text alone
+        // reads as a frozen badge for multi-second waits (#19).
+        busyDot_ = new brls::Label();
+        busyDot_->setText("●");
+        busyDot_->setFontSize(theme::kFontCaption);
+        busyDot_->setTextColor(theme::warning());
+        busyDot_->setMarginRight(6);
+        busyDot_->setFocusable(false);
+        busyDot_->setShrink(0.0f);
+        busyDot_->setVisibility(brls::Visibility::GONE);
+        freshnessRow_->addView(busyDot_);
         freshness_ = new brls::Label();
         freshness_->setFontSize(theme::kFontCaption);
         freshness_->setSingleLine(true);
@@ -457,6 +469,7 @@ public:
         alive_->store(false);
         cancelled_->store(true);
         timer_.stop();
+        stopBusyPulse(busyDot_);
     }
 
     void openSearchKeyboard() {
@@ -1464,6 +1477,15 @@ private:
     void setBusy(bool busy) {
         busy_ = busy;
         registerSortAction(busy);
+        if (busyDot_) {
+            if (busy) {
+                busyDot_->setVisibility(brls::Visibility::VISIBLE);
+                startBusyPulse(busyDot_);
+            } else {
+                stopBusyPulse(busyDot_);
+                busyDot_->setVisibility(brls::Visibility::GONE);
+            }
+        }
         updateFreshnessLabel();
         // Neither registerAction nor updateActionHint fires this, so without it
         // the bar keeps the stale hint until some unrelated focus change
@@ -1817,6 +1839,7 @@ private:
     CatalogDataSource* dataSource_;
     brls::Box* header_ = nullptr;
     brls::Box* freshnessRow_ = nullptr;
+    brls::Label* busyDot_ = nullptr;
     brls::Label* freshness_ = nullptr;
     SearchIconButton* searchField_ = nullptr;
     brls::Button* clearSearch_ = nullptr;

--- a/src/ui/common/busy_pulse.hpp
+++ b/src/ui/common/busy_pulse.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <borealis.hpp>
+
+namespace pipensx::ui {
+
+// Soft alpha pulse on an existing View — no new widget class. Drive the
+// view's public Animatable alpha between lo/hi until stopBusyPulse().
+inline void startBusyPulse(brls::View* view) {
+    if (!view)
+        return;
+    constexpr float kLo = 0.35f;
+    constexpr float kHi = 1.0f;
+    constexpr int32_t kHalfMs = 550;
+    view->alpha.stop();
+    view->alpha.reset(kHi);
+    view->alpha.setEndCallback([view](bool done) {
+        if (done)
+            startBusyPulse(view);
+    });
+    view->alpha.addStep(kLo, kHalfMs, brls::EasingFunction::quadraticInOut);
+    view->alpha.addStep(kHi, kHalfMs, brls::EasingFunction::quadraticInOut);
+    view->alpha.start();
+}
+
+inline void stopBusyPulse(brls::View* view) {
+    if (!view)
+        return;
+    view->alpha.setEndCallback([](bool) {});
+    view->alpha.stop();
+    view->setAlpha(1.0f);
+}
+
+}  // namespace pipensx::ui

--- a/src/ui/detail/game_detail.hpp
+++ b/src/ui/detail/game_detail.hpp
@@ -25,6 +25,7 @@
 #include "app/nx_file_types.hpp"
 #include "ui/catalog/catalog_helpers.hpp"
 #include "ui/common/async_image.hpp"
+#include "ui/common/busy_pulse.hpp"
 #include "ui/common/storage_meter.hpp"
 #include "ui/common/ui_helpers.hpp"
 #include "ui/detail/screenshot_viewer.hpp"
@@ -123,6 +124,8 @@ public:
         alive_->store(false);
         cancelled_->store(true);
         timer_.stop();
+        stopBusyPulse(primary_);
+        stopBusyPulse(statusLabel_);
         if (onChange_)
             onChange_();  // refresh the row badge on the way back
         // O12: deferred a frame — the activity is mid-teardown here and
@@ -578,8 +581,18 @@ private:
                                     sizeExact_);
     }
 
-    // Reflect live task state on the buttons. Skipped while resolving so the
-    // inline progress text isn't clobbered.
+    // Pulse Install + status while magnet/debrid resolve is in flight (#19).
+    void setBusy(bool busy) {
+        busy_ = busy;
+        if (busy) {
+            startBusyPulse(primary_);
+            startBusyPulse(statusLabel_);
+        } else {
+            stopBusyPulse(primary_);
+            stopBusyPulse(statusLabel_);
+        }
+    }
+
     // Star/unstar this game. The cap is reported in the user's words; any
     // other failure is a write error worth showing verbatim.
     void onFavorite() {
@@ -619,6 +632,8 @@ private:
                                     : &brls::BUTTONSTYLE_DEFAULT);
     }
 
+    // Reflect live task state on the buttons. Skipped while resolving so the
+    // inline progress text isn't clobbered.
     void refreshButtons() {
         refreshFavoriteButton();
         if (busy_)
@@ -705,7 +720,7 @@ private:
             startDebridInstall(TransferMode::StreamInstall, forcePicker);
             return;
         }
-        busy_ = true;
+        setBusy(true);
         operationMessage_.clear();
         cancelled_->store(false);
         primary_->setState(brls::ButtonState::DISABLED);
@@ -771,7 +786,7 @@ private:
                     ::unlink(tmp.c_str());
                     return;
                 }
-                busy_ = false;
+                setBusy(false);
                 std::string hash = catalogLower(entry_.infoHash);
                 if (!ok) {
                     std::string reason = classifyResolveFailure(err);
@@ -795,7 +810,7 @@ private:
     void startDebridInstall(TransferMode mode, bool forcePicker = false) {
         if (busy_ || !ensureDebridLinked(settings_, manager_))
             return;
-        busy_ = true;
+        setBusy(true);
         cancelled_->store(false);
         primary_->setState(brls::ButtonState::DISABLED);
         secondary_->setState(brls::ButtonState::DISABLED);
@@ -847,12 +862,12 @@ private:
                     if (!debridId.empty())
                         removeDebridTransferAsync(providerKind, key, debridId);
                     if (alive->load()) {
-                        busy_ = false;
+                        setBusy(false);
                         refreshButtons();
                     }
                     return;
                 }
-                busy_ = false;
+                setBusy(false);
                 if (!ok) {
                     if (!debridId.empty())
                         removeDebridTransferAsync(providerKind, key, debridId);


### PR DESCRIPTION
## Summary
- Soft alpha pulse on existing borealis Views during long waits (catalog refresh, magnet/debrid resolve)
- Pulsing dot next to the catalog freshness badge; Install button and status label pulse while busy

Closes #19

## Test plan
- [x] `make -f Makefile.pc test`
- [x] `make golden`
- [ ] On device: trigger catalog refresh and confirm the orange ● pulses next to "Updating…"
- [ ] On device: start Install (torrent or debrid) and confirm the Install button + status text pulse until resolve finishes


Made with [Cursor](https://cursor.com)