### PR TITLE
Makefile.pc: wildcard test discovery + CORE_SOURCES sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
             build-essential python3 libcurl4-openssl-dev libssl-dev \
             libzstd-dev zlib1g-dev
 
+      - name: Check Makefile.pc ↔ CMakeLists source lists
+        run: python3 scripts/check_source_lists.py
+
       - name: Run PC tests
         run: make test
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,6 @@ set(CORE_SOURCES
     src/core/peer.c
     src/core/piece.c
     src/core/tracker.c
-    src/core/mse.c
     src/core/dht.c
     src/core/torrent.c
     src/platform/storage.c

--- a/Makefile.pc
+++ b/Makefile.pc
@@ -41,7 +41,9 @@ UTP_OBJS     = $(addprefix $(BUILD_DIR)/$(UTP_DIR)/, \
 UTP_CXXFLAGS = -O2 -std=c++17 -DPOSIX -DNDEBUG -Ivendor/libutp \
                -fpermissive -fno-exceptions -fno-rtti -Wno-sign-compare
 
-SRCS = \
+# Shared with CMakeLists.txt CORE_SOURCES (minus Switch-only bits).
+# scripts/check_source_lists.py cross-checks the two.
+CORE_SOURCES = \
     src/core/sha1.c       \
     src/core/sha256.c     \
     src/core/mse.c        \
@@ -55,52 +57,18 @@ SRCS = \
     src/core/dht.c        \
     src/core/torrent.c    \
     src/platform/storage.c \
-    vendor/dht/dht.c      \
-    src/main_pc.c
+    vendor/dht/dht.c
+
+SRCS = $(CORE_SOURCES) src/main_pc.c
 
 OBJS = $(addprefix $(BUILD_DIR)/,$(SRCS:.c=.o))
-TEST_TARGET = $(BUILD_DIR)/tests/test_piece
-MANAGER_TEST_TARGET = $(BUILD_DIR)/tests/test_manager
-PACKAGE_TEST_TARGET = $(BUILD_DIR)/tests/test_package_stream
-CATALOG_TEST_TARGET = $(BUILD_DIR)/tests/test_catalog
-TELEMETRY_TEST_TARGET = $(BUILD_DIR)/tests/test_telemetry
-PEER_TEST_TARGET = $(BUILD_DIR)/tests/test_peer
-TRACKER_TEST_TARGET = $(BUILD_DIR)/tests/test_tracker
-TORRENT_TEST_TARGET = $(BUILD_DIR)/tests/test_torrent
-SETTINGS_TEST_TARGET = $(BUILD_DIR)/tests/test_app_settings
-FAVORITES_TEST_TARGET = $(BUILD_DIR)/tests/test_favorites
-UPDATE_TEST_TARGET = $(BUILD_DIR)/tests/test_update_service
-GAME_UPDATE_TEST_TARGET = $(BUILD_DIR)/tests/test_game_update_service
-UPDATE_FILE_SELECT_TEST_TARGET = $(BUILD_DIR)/tests/test_update_file_select
-UPDATE_TRANSACTION_TEST_TARGET = $(BUILD_DIR)/tests/test_update_transaction
-INSTALL_SPACE_TEST_TARGET = $(BUILD_DIR)/tests/test_install_space
-BATCH_INSTALL_TEST_TARGET = $(BUILD_DIR)/tests/test_batch_install
-RAM_BUDGET_TEST_TARGET = $(BUILD_DIR)/tests/test_stream_ram_budget
-BUDGET_ARBITER_TEST_TARGET = $(BUILD_DIR)/tests/test_budget_arbiter
-REQUEST_GATE_TEST_TARGET = $(BUILD_DIR)/tests/test_request_gate
-INSTALL_PACER_TEST_TARGET = $(BUILD_DIR)/tests/test_install_pacer
-JOURNAL_TEST_TARGET = $(BUILD_DIR)/tests/test_install_journal
-PACKAGE_COORDINATOR_TEST_TARGET = $(BUILD_DIR)/tests/test_package_coordinator
-WEB_SEED_TEST_TARGET = $(BUILD_DIR)/tests/test_web_seed
-WEB_SEED_BACKOFF_TEST_TARGET = $(BUILD_DIR)/tests/test_web_seed_backoff
-MSE_TEST_TARGET = $(BUILD_DIR)/tests/test_mse
-DHT_CACHE_TEST_TARGET = $(BUILD_DIR)/tests/test_dht_cache
-DHT_SHARED_TEST_TARGET = $(BUILD_DIR)/tests/test_dht_shared
-BUG_REPORT_TEST_TARGET = $(BUILD_DIR)/tests/test_bug_report
-HTTP_TEST_TARGET = $(BUILD_DIR)/tests/test_http_server
-WEB_SERVER_TEST_TARGET = $(BUILD_DIR)/tests/test_web_server
-PROBE_REPORT_TEST_TARGET = $(BUILD_DIR)/tests/test_probe_report
-TORBOX_CLIENT_TEST_TARGET = $(BUILD_DIR)/tests/test_torbox_client
-TORBOX_PAIRING_TEST_TARGET = $(BUILD_DIR)/tests/test_torbox_pairing
-SSL_CACERT_TEST_TARGET = $(BUILD_DIR)/tests/test_ssl_cacert
-DEBRID_TRANSFER_TEST_TARGET = $(BUILD_DIR)/tests/test_debrid_transfer
-TB_PROVIDER_TEST_TARGET = $(BUILD_DIR)/tests/test_torbox_provider
-TS_PROVIDER_TEST_TARGET = $(BUILD_DIR)/tests/test_torrserver_provider
-RD_CLIENT_TEST_TARGET = $(BUILD_DIR)/tests/test_realdebrid_client
-RD_PROVIDER_TEST_TARGET = $(BUILD_DIR)/tests/test_realdebrid_provider
-TASK_FILES_TEST_TARGET = $(BUILD_DIR)/tests/test_task_files
-SWITCH_DEPLOY_TEST_TARGET = $(BUILD_DIR)/tests/test_switch_deploy
-PORT_ARCHIVE_TEST_TARGET = $(BUILD_DIR)/tests/test_port_archive
+# Native tests discovered by filename. Build rules below still spell out
+# link deps; forgetting a run line is impossible — `test` runs every bin.
+TEST_SOURCES := $(wildcard tests/test_*.c tests/test_*.cpp)
+TEST_BINS := $(sort $(patsubst tests/%,$(BUILD_DIR)/tests/%,$(basename $(TEST_SOURCES))))
+# DHT against live routers — always last so a bad network cannot hide others.
+TEST_BINS_EARLY := $(filter-out $(BUILD_DIR)/tests/test_manager,$(TEST_BINS))
+
 TEST_SRCS = \
     tests/test_piece.c       \
     src/core/sha1.c          \
@@ -124,7 +92,7 @@ $(BUILD_DIR)/$(UTP_DIR)/%.o: $(UTP_DIR)/%.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(UTP_CXXFLAGS) -c -o $@ $<
 
-$(TEST_TARGET): $(TEST_SRCS)
+$(BUILD_DIR)/tests/test_piece: $(TEST_SRCS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
@@ -209,7 +177,7 @@ $(BUILD_DIR)/tests/test_manager.o: tests/test_manager.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
-$(MANAGER_TEST_TARGET): $(BUILD_DIR)/tests/test_manager.o $(BUILD_DIR)/src/app/download_manager.o \
+$(BUILD_DIR)/tests/test_manager: $(BUILD_DIR)/tests/test_manager.o $(BUILD_DIR)/src/app/download_manager.o \
 		$(BUILD_DIR)/src/app/task_files.o \
 		$(BUILD_DIR)/src/app/web_seed_source.o \
 		$(BUILD_DIR)/src/app/stream_ram_budget.o $(BUILD_DIR)/src/app/stream_budget_arbiter.o \
@@ -224,7 +192,7 @@ $(MANAGER_TEST_TARGET): $(BUILD_DIR)/tests/test_manager.o $(BUILD_DIR)/src/app/d
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(INSTALL_LDFLAGS) -pthread
 
-$(PACKAGE_TEST_TARGET): tests/test_package_stream.cpp \
+$(BUILD_DIR)/tests/test_package_stream: tests/test_package_stream.cpp \
 		$(BUILD_DIR)/src/install/package_stream.o $(BUILD_DIR)/src/install/install_backend_pc.o \
 		$(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
@@ -271,12 +239,12 @@ $(BUILD_DIR)/src/app/web_add_queue.o: src/app/web_add_queue.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -c -o $@ $<
 
-$(HTTP_TEST_TARGET): tests/test_http_server.cpp $(BUILD_DIR)/src/app/http_server.o \
+$(BUILD_DIR)/tests/test_http_server: tests/test_http_server.cpp $(BUILD_DIR)/src/app/http_server.o \
 		$(BUILD_DIR)/src/core/net.o $(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ -pthread
 
-$(WEB_SERVER_TEST_TARGET): tests/test_web_server.cpp \
+$(BUILD_DIR)/tests/test_web_server: tests/test_web_server.cpp \
 		$(BUILD_DIR)/src/app/web_server.o $(BUILD_DIR)/src/app/web_add_queue.o $(BUILD_DIR)/src/app/http_server.o \
 		$(BUILD_DIR)/src/app/magnet_resolver.o src/app/install_space.cpp \
 		$(BUILD_DIR)/src/app/download_manager.o $(BUILD_DIR)/src/app/task_files.o \
@@ -294,7 +262,7 @@ $(WEB_SERVER_TEST_TARGET): tests/test_web_server.cpp \
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS) \
 		$(INSTALL_LDFLAGS) -lz -pthread
 
-$(CATALOG_TEST_TARGET): tests/test_catalog.cpp \
+$(BUILD_DIR)/tests/test_catalog: tests/test_catalog.cpp \
 		$(BUILD_DIR)/src/app/catalog_service.o $(BUILD_DIR)/src/app/catalog_refresh.o \
 		$(BUILD_DIR)/src/app/catalog_presentation.o \
 		$(BUILD_DIR)/src/app/snapshot_zstd.o \
@@ -312,123 +280,58 @@ $(CATALOG_TEST_TARGET): tests/test_catalog.cpp \
 # The sysmodule probe's telemetry (sample ring, event log, ini parser) is plain
 # C with no libnx, so the PC build covers it. The rest of src/probe is Switch
 # services and only builds under CMake.
-$(PROBE_REPORT_TEST_TARGET): tests/test_probe_report.c src/probe/probe_report.c
+$(BUILD_DIR)/tests/test_probe_report: tests/test_probe_report.c src/probe/probe_report.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -o $@ $^
 
-test: $(TEST_TARGET) $(MANAGER_TEST_TARGET) $(PACKAGE_TEST_TARGET) \
-		$(CATALOG_TEST_TARGET) \
-		$(TELEMETRY_TEST_TARGET) $(PEER_TEST_TARGET) \
-		$(TRACKER_TEST_TARGET) $(TORRENT_TEST_TARGET) \
-		$(SETTINGS_TEST_TARGET) $(UPDATE_TEST_TARGET) \
-		$(GAME_UPDATE_TEST_TARGET) \
-		$(UPDATE_FILE_SELECT_TEST_TARGET) \
-		$(UPDATE_TRANSACTION_TEST_TARGET) \
-		$(INSTALL_SPACE_TEST_TARGET) $(BATCH_INSTALL_TEST_TARGET) \
-		$(RAM_BUDGET_TEST_TARGET) $(BUDGET_ARBITER_TEST_TARGET) \
-		$(REQUEST_GATE_TEST_TARGET) \
-		$(INSTALL_PACER_TEST_TARGET) \
-		$(JOURNAL_TEST_TARGET) $(PACKAGE_COORDINATOR_TEST_TARGET) \
-		$(WEB_SEED_TEST_TARGET) \
-		$(WEB_SEED_BACKOFF_TEST_TARGET) \
-		$(FAVORITES_TEST_TARGET) \
-		$(MSE_TEST_TARGET) $(DHT_CACHE_TEST_TARGET) \
-		$(DHT_SHARED_TEST_TARGET) \
-		$(BUG_REPORT_TEST_TARGET) \
-		$(HTTP_TEST_TARGET) $(WEB_SERVER_TEST_TARGET) \
-		$(PROBE_REPORT_TEST_TARGET) \
-		$(TORBOX_CLIENT_TEST_TARGET) $(TORBOX_PAIRING_TEST_TARGET) \
-		$(SSL_CACERT_TEST_TARGET) \
-		$(DEBRID_TRANSFER_TEST_TARGET) \
-		$(TB_PROVIDER_TEST_TARGET) $(TS_PROVIDER_TEST_TARGET) \
-		$(RD_CLIENT_TEST_TARGET) $(RD_PROVIDER_TEST_TARGET) \
-		$(TASK_FILES_TEST_TARGET) $(SWITCH_DEPLOY_TEST_TARGET) \
-		$(PORT_ARCHIVE_TEST_TARGET)
-	./$(TEST_TARGET)
-	./$(PACKAGE_TEST_TARGET)
-	./$(CATALOG_TEST_TARGET)
-	./$(TELEMETRY_TEST_TARGET)
-	./$(PEER_TEST_TARGET)
-	./$(TRACKER_TEST_TARGET)
-	./$(TORRENT_TEST_TARGET)
-	./$(SETTINGS_TEST_TARGET)
-	./$(UPDATE_TEST_TARGET)
-	./$(GAME_UPDATE_TEST_TARGET)
-	./$(UPDATE_FILE_SELECT_TEST_TARGET)
-	./$(UPDATE_TRANSACTION_TEST_TARGET)
-	./$(INSTALL_SPACE_TEST_TARGET)
-	./$(BATCH_INSTALL_TEST_TARGET)
-	./$(RAM_BUDGET_TEST_TARGET)
-	./$(BUDGET_ARBITER_TEST_TARGET)
-	./$(REQUEST_GATE_TEST_TARGET)
-	./$(INSTALL_PACER_TEST_TARGET)
-	./$(JOURNAL_TEST_TARGET)
-	./$(PACKAGE_COORDINATOR_TEST_TARGET)
-	./$(WEB_SEED_TEST_TARGET)
-	./$(WEB_SEED_BACKOFF_TEST_TARGET)
-	./$(FAVORITES_TEST_TARGET)
-	./$(MSE_TEST_TARGET)
-	./$(DHT_CACHE_TEST_TARGET)
-	./$(DHT_SHARED_TEST_TARGET)
-	./$(BUG_REPORT_TEST_TARGET)
-	./$(HTTP_TEST_TARGET)
-	./$(WEB_SERVER_TEST_TARGET)
-	./$(PROBE_REPORT_TEST_TARGET)
-	./$(TORBOX_CLIENT_TEST_TARGET)
-	./$(TORBOX_PAIRING_TEST_TARGET)
-	./$(SSL_CACERT_TEST_TARGET)
-	./$(DEBRID_TRANSFER_TEST_TARGET)
-	./$(TB_PROVIDER_TEST_TARGET)
-	./$(TS_PROVIDER_TEST_TARGET)
-	./$(RD_CLIENT_TEST_TARGET)
-	./$(RD_PROVIDER_TEST_TARGET)
-	./$(TASK_FILES_TEST_TARGET)
-	./$(SWITCH_DEPLOY_TEST_TARGET)
-	./$(PORT_ARCHIVE_TEST_TARGET)
+test: $(TEST_BINS)
+	python3 scripts/check_source_lists.py
+	@set -e; for t in $(TEST_BINS_EARLY); do echo "== $$t"; ./$$t; done
 	python3 tests/test_bug_report_decode.py
 	python3 tests/test_telemetry_analyzer.py
 	python3 scripts/check_i18n.py
 	# last: bootstraps DHT against live routers, so it fails on a bad
-	# network. Running it here keeps that from hiding the other 25.
-	./$(MANAGER_TEST_TARGET)
+	# network. Running it here keeps that from hiding the other tests.
+	./$(BUILD_DIR)/tests/test_manager
 
-$(SETTINGS_TEST_TARGET): tests/test_app_settings.cpp src/app/app_settings.cpp \
+
+$(BUILD_DIR)/tests/test_app_settings: tests/test_app_settings.cpp src/app/app_settings.cpp \
 		$(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
 
-$(UPDATE_TEST_TARGET): tests/test_update_service.cpp src/app/update_service.cpp \
+$(BUILD_DIR)/tests/test_update_service: tests/test_update_service.cpp src/app/update_service.cpp \
 		$(BUILD_DIR)/src/app/update_transaction.o src/core/sha256.c
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS) -Wl,--wrap=rename
 
-$(GAME_UPDATE_TEST_TARGET): tests/test_game_update_service.cpp \
+$(BUILD_DIR)/tests/test_game_update_service: tests/test_game_update_service.cpp \
 		src/app/game_update_service.cpp src/app/update_service.cpp \
 		$(BUILD_DIR)/src/app/update_transaction.o src/core/sha256.c $(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS)
 
-$(UPDATE_FILE_SELECT_TEST_TARGET): tests/test_update_file_select.cpp \
+$(BUILD_DIR)/tests/test_update_file_select: tests/test_update_file_select.cpp \
 		src/app/game_update_install.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
 
-$(UPDATE_TRANSACTION_TEST_TARGET): tests/test_update_transaction.c \
+$(BUILD_DIR)/tests/test_update_transaction: tests/test_update_transaction.c \
 		src/app/update_transaction.c src/core/sha256.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -Isrc -o $@ $^ -Wl,--wrap=rename
 
-$(INSTALL_SPACE_TEST_TARGET): tests/test_install_space.cpp \
+$(BUILD_DIR)/tests/test_install_space: tests/test_install_space.cpp \
 		src/app/install_space.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
 
-$(FAVORITES_TEST_TARGET): tests/test_favorites.cpp \
+$(BUILD_DIR)/tests/test_favorites: tests/test_favorites.cpp \
 		src/app/favorites_service.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
 
-$(BATCH_INSTALL_TEST_TARGET): tests/test_batch_install.cpp \
+$(BUILD_DIR)/tests/test_batch_install: tests/test_batch_install.cpp \
 		src/app/catalog_batch_installer.cpp src/app/install_space.cpp \
 		$(BUILD_DIR)/src/app/download_manager.o $(BUILD_DIR)/src/app/task_files.o \
 		$(BUILD_DIR)/src/app/web_seed_source.o \
@@ -445,32 +348,32 @@ $(BATCH_INSTALL_TEST_TARGET): tests/test_batch_install.cpp \
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS) \
 		$(INSTALL_LDFLAGS) -pthread
 
-$(RAM_BUDGET_TEST_TARGET): tests/test_stream_ram_budget.cpp \
+$(BUILD_DIR)/tests/test_stream_ram_budget: tests/test_stream_ram_budget.cpp \
 		src/app/stream_ram_budget.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
 
-$(BUDGET_ARBITER_TEST_TARGET): tests/test_budget_arbiter.cpp \
+$(BUILD_DIR)/tests/test_budget_arbiter: tests/test_budget_arbiter.cpp \
 		src/app/stream_budget_arbiter.cpp src/app/stream_ram_budget.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
 
-$(REQUEST_GATE_TEST_TARGET): tests/test_request_gate.cpp \
+$(BUILD_DIR)/tests/test_request_gate: tests/test_request_gate.cpp \
 		src/app/request_gate.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
 
-$(INSTALL_PACER_TEST_TARGET): tests/test_install_pacer.cpp \
+$(BUILD_DIR)/tests/test_install_pacer: tests/test_install_pacer.cpp \
 		src/app/install_pacer.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ -pthread
 
-$(JOURNAL_TEST_TARGET): tests/test_install_journal.cpp \
+$(BUILD_DIR)/tests/test_install_journal: tests/test_install_journal.cpp \
 		$(BUILD_DIR)/src/install/install_journal.o $(BUILD_DIR)/src/core/bencode.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
 
-$(PACKAGE_COORDINATOR_TEST_TARGET): tests/test_package_coordinator.cpp \
+$(BUILD_DIR)/tests/test_package_coordinator: tests/test_package_coordinator.cpp \
 		$(BUILD_DIR)/src/app/stream_ram_budget.o $(BUILD_DIR)/src/app/stream_budget_arbiter.o \
 		$(BUILD_DIR)/src/app/request_gate.o $(BUILD_DIR)/src/app/install_pacer.o \
 		$(BUILD_DIR)/src/install/package_stream.o $(BUILD_DIR)/src/install/install_journal.o \
@@ -480,75 +383,75 @@ $(PACKAGE_COORDINATOR_TEST_TARGET): tests/test_package_coordinator.cpp \
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $(filter-out src/app/package_coordinator.hpp,$^) $(INSTALL_LDFLAGS) -pthread
 
-$(PACKAGE_COORDINATOR_TEST_TARGET): src/app/package_coordinator.hpp
+$(BUILD_DIR)/tests/test_package_coordinator: src/app/package_coordinator.hpp
 
-$(WEB_SEED_TEST_TARGET): tests/test_web_seed.cpp $(BUILD_DIR)/src/app/web_seed_source.o \
+$(BUILD_DIR)/tests/test_web_seed: tests/test_web_seed.cpp $(BUILD_DIR)/src/app/web_seed_source.o \
 		$(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS) -pthread
 
-$(WEB_SEED_BACKOFF_TEST_TARGET): tests/test_web_seed_backoff.cpp $(BUILD_DIR)/src/app/web_seed_source.o \
+$(BUILD_DIR)/tests/test_web_seed_backoff: tests/test_web_seed_backoff.cpp $(BUILD_DIR)/src/app/web_seed_source.o \
 		$(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS) -pthread
 
-$(MSE_TEST_TARGET): tests/test_mse.c src/core/mse.c src/core/sha1.c \
+$(BUILD_DIR)/tests/test_mse: tests/test_mse.c src/core/mse.c src/core/sha1.c \
 	src/core/util.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -Isrc -o $@ $^ $(LDFLAGS) -lcrypto
 
-$(DHT_CACHE_TEST_TARGET): tests/test_dht_cache.c src/core/dht.c \
+$(BUILD_DIR)/tests/test_dht_cache: tests/test_dht_cache.c src/core/dht.c \
 		vendor/dht/dht.c src/core/net.c src/core/sha1.c src/core/util.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -Isrc -o $@ $^ $(LDFLAGS)
 
 # dht.c is a real prerequisite (the test #includes it as source) but must
 # not be passed to the compiler a second time — hence the filter-out in $^.
-$(DHT_SHARED_TEST_TARGET): tests/test_dht_shared.c src/core/dht.c \
+$(BUILD_DIR)/tests/test_dht_shared: tests/test_dht_shared.c src/core/dht.c \
 		vendor/dht/dht.c src/core/net.c src/core/sha1.c src/core/util.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -Isrc -o $@ $(filter-out src/core/dht.c,$^) $(LDFLAGS)
 
-$(BUG_REPORT_TEST_TARGET): tests/test_bug_report.cpp src/app/bug_report.cpp
+$(BUILD_DIR)/tests/test_bug_report: tests/test_bug_report.cpp src/app/bug_report.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ -lz
 
-$(TORBOX_CLIENT_TEST_TARGET): tests/test_torbox_client.cpp \
+$(BUILD_DIR)/tests/test_torbox_client: tests/test_torbox_client.cpp \
 		$(BUILD_DIR)/src/app/torbox_client.o $(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS)
 
-$(TB_PROVIDER_TEST_TARGET): tests/test_torbox_provider.cpp \
+$(BUILD_DIR)/tests/test_torbox_provider: tests/test_torbox_provider.cpp \
 		$(BUILD_DIR)/src/app/torbox_provider.o $(BUILD_DIR)/src/app/torbox_client.o $(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS)
 
-$(TS_PROVIDER_TEST_TARGET): tests/test_torrserver_provider.cpp \
+$(BUILD_DIR)/tests/test_torrserver_provider: tests/test_torrserver_provider.cpp \
 		$(BUILD_DIR)/src/app/torrserver_provider.o $(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS)
 
-$(RD_CLIENT_TEST_TARGET): tests/test_realdebrid_client.cpp \
+$(BUILD_DIR)/tests/test_realdebrid_client: tests/test_realdebrid_client.cpp \
 		$(BUILD_DIR)/src/app/realdebrid_client.o $(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS)
 
-$(RD_PROVIDER_TEST_TARGET): tests/test_realdebrid_provider.cpp \
+$(BUILD_DIR)/tests/test_realdebrid_provider: tests/test_realdebrid_provider.cpp \
 		$(BUILD_DIR)/src/app/realdebrid_provider.o $(BUILD_DIR)/src/app/realdebrid_client.o $(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS)
 
-$(TORBOX_PAIRING_TEST_TARGET): tests/test_torbox_pairing.cpp \
+$(BUILD_DIR)/tests/test_torbox_pairing: tests/test_torbox_pairing.cpp \
 		$(BUILD_DIR)/src/app/torbox_pairing_server.o $(BUILD_DIR)/src/app/http_server.o \
 		$(BUILD_DIR)/src/core/net.o $(BUILD_DIR)/src/core/util.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS) -pthread
 
-$(SSL_CACERT_TEST_TARGET): tests/test_ssl_cacert.cpp
+$(BUILD_DIR)/tests/test_ssl_cacert: tests/test_ssl_cacert.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $< $(LDFLAGS)
 
-$(DEBRID_TRANSFER_TEST_TARGET): tests/test_debrid_transfer.cpp \
+$(BUILD_DIR)/tests/test_debrid_transfer: tests/test_debrid_transfer.cpp \
 		$(BUILD_DIR)/src/app/debrid_transfer.o $(BUILD_DIR)/src/app/torbox_client.o \
 		$(BUILD_DIR)/src/app/install_pacer.o \
 		$(BUILD_DIR)/src/app/stream_ram_budget.o \
@@ -558,14 +461,14 @@ $(DEBRID_TRANSFER_TEST_TARGET): tests/test_debrid_transfer.cpp \
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS) $(INSTALL_LDFLAGS) -pthread
 
-$(TASK_FILES_TEST_TARGET): tests/test_task_files.cpp \
+$(BUILD_DIR)/tests/test_task_files: tests/test_task_files.cpp \
 		$(BUILD_DIR)/src/app/task_files.o $(BUILD_DIR)/src/core/bencode.o \
 		$(BUILD_DIR)/src/core/metainfo.o $(BUILD_DIR)/src/core/sha1.o \
 		$(BUILD_DIR)/src/core/util.o $(BUILD_DIR)/src/platform/storage.o
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS)
 
-$(SWITCH_DEPLOY_TEST_TARGET): tests/test_switch_deploy.cpp \
+$(BUILD_DIR)/tests/test_switch_deploy: tests/test_switch_deploy.cpp \
 		$(BUILD_DIR)/src/app/switch_deploy.o $(BUILD_DIR)/src/app/task_files.o \
 		$(BUILD_DIR)/src/app/port_archive.o $(LZMA_OBJS) \
 		$(BUILD_DIR)/src/app/download_manager.o src/app/install_space.cpp \
@@ -581,7 +484,7 @@ $(SWITCH_DEPLOY_TEST_TARGET): tests/test_switch_deploy.cpp \
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS) $(INSTALL_LDFLAGS) -lz -pthread
 
-$(PORT_ARCHIVE_TEST_TARGET): tests/test_port_archive.cpp \
+$(BUILD_DIR)/tests/test_port_archive: tests/test_port_archive.cpp \
 		$(BUILD_DIR)/src/app/port_archive.o $(BUILD_DIR)/src/app/task_files.o \
 		$(LZMA_OBJS) $(BUILD_DIR)/src/core/bencode.o $(BUILD_DIR)/src/core/metainfo.o \
 		$(BUILD_DIR)/src/core/sha1.o $(BUILD_DIR)/src/core/util.o \
@@ -589,17 +492,17 @@ $(PORT_ARCHIVE_TEST_TARGET): tests/test_port_archive.cpp \
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^ $(LDFLAGS) -lz
 
-$(TELEMETRY_TEST_TARGET): tests/test_telemetry.c src/core/util.c
+$(BUILD_DIR)/tests/test_telemetry: tests/test_telemetry.c src/core/util.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -Isrc -o $@ $^ $(LDFLAGS)
 
-$(PEER_TEST_TARGET): tests/test_peer.c src/core/peer.c src/core/net.c \
+$(BUILD_DIR)/tests/test_peer: tests/test_peer.c src/core/peer.c src/core/net.c \
 		src/core/bencode.c src/core/util.c src/core/mse.c src/core/sha1.c \
 		$(UTP_OBJS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -Isrc -o $@ $^ $(LDFLAGS) -lstdc++ -Wl,--wrap=setsockopt
 
-$(TRACKER_TEST_TARGET): tests/test_tracker.c src/core/tracker.c \
+$(BUILD_DIR)/tests/test_tracker: tests/test_tracker.c src/core/tracker.c \
 		src/core/bencode.c src/core/util.c src/core/net.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -Isrc -o $@ $(filter-out src/core/tracker.c,$^) \
@@ -607,7 +510,7 @@ $(TRACKER_TEST_TARGET): tests/test_tracker.c src/core/tracker.c \
 
 # torrent.c is a real prerequisite (the test #includes it as source) but must
 # not be passed to the compiler a second time — hence the filter-out in $^.
-$(TORRENT_TEST_TARGET): tests/test_torrent.c src/core/torrent.c \
+$(BUILD_DIR)/tests/test_torrent: tests/test_torrent.c src/core/torrent.c \
 		$(filter-out $(BUILD_DIR)/src/core/torrent.o $(BUILD_DIR)/src/main_pc.o,$(OBJS)) $(UTP_OBJS)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -Isrc -o $@ $(filter-out src/core/torrent.c,$^) \

--- a/scripts/check_source_lists.py
+++ b/scripts/check_source_lists.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Cross-check CORE_SOURCES between Makefile.pc and CMakeLists.txt.
+
+A drift here means the PC CLI/tests and the Switch/golden builds compile
+different cores. APP_SERVICE_SOURCES / UI_SOURCES live only in CMake
+(Switch + golden_runner); Makefile.pc pulls those in per-test.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def parse_make_list(text: str, name: str) -> list[str]:
+    m = re.search(
+        rf"^{re.escape(name)}\s*=\s*\\?\s*\n((?:[ \t]+.+\n)+)",
+        text,
+        flags=re.M,
+    )
+    if not m:
+        raise SystemExit(f"Makefile.pc: {name} list not found")
+    files: list[str] = []
+    for line in m.group(1).splitlines():
+        tok = line.strip().rstrip("\\").strip()
+        if tok:
+            files.append(tok)
+    return files
+
+
+def parse_cmake_set(text: str, name: str) -> list[str]:
+    m = re.search(
+        rf"set\(\s*{re.escape(name)}\s*((?:.|\n)*?)\)",
+        text,
+    )
+    if not m:
+        raise SystemExit(f"CMakeLists.txt: set({name} ...) not found")
+    files = re.findall(r"(src/[^\s)]+|vendor/[^\s)]+)", m.group(1))
+    return files
+
+
+def main() -> int:
+    make = (ROOT / "Makefile.pc").read_text()
+    cmake = (ROOT / "CMakeLists.txt").read_text()
+
+    make_core = parse_make_list(make, "CORE_SOURCES")
+    cmake_core = parse_cmake_set(cmake, "CORE_SOURCES")
+
+    errors: list[str] = []
+
+    if len(cmake_core) != len(set(cmake_core)):
+        dupes = sorted({f for f in cmake_core if cmake_core.count(f) > 1})
+        errors.append(f"CMakeLists.txt CORE_SOURCES has duplicates: {dupes}")
+
+    if len(make_core) != len(set(make_core)):
+        dupes = sorted({f for f in make_core if make_core.count(f) > 1})
+        errors.append(f"Makefile.pc CORE_SOURCES has duplicates: {dupes}")
+
+    a, b = set(make_core), set(cmake_core)
+    only_make = sorted(a - b)
+    only_cmake = sorted(b - a)
+    if only_make or only_cmake:
+        errors.append("CORE_SOURCES mismatch between Makefile.pc and CMakeLists.txt")
+        if only_make:
+            errors.append("  only in Makefile.pc: " + ", ".join(only_make))
+        if only_cmake:
+            errors.append("  only in CMakeLists.txt: " + ", ".join(only_cmake))
+
+    # Order need not match, but report sorted for stable diffs.
+    if not errors and make_core != cmake_core:
+        # Same set, different order — fine.
+        pass
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+
+    print(f"OK: CORE_SOURCES ({len(make_core)} files) match Makefile.pc ↔ CMakeLists.txt")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Discover and run native tests from `tests/test_*.{c,cpp}` so a forgotten run line cannot silently skip a test (`test_manager` still last).
- Name shared `CORE_SOURCES` in `Makefile.pc`, drop the duplicate `mse.c` in CMake, and add `scripts/check_source_lists.py` (wired into CI + `make test`).

Closes #20

## Test plan
- [x] `python3 scripts/check_source_lists.py`
- [x] `make -f Makefile.pc clean && make -f Makefile.pc test`
- [x] `make pc`

Made with [Cursor](https://cursor.com)