### PR TITLE
fix(install): keep port payloads selected

### DIFF
--- a/src/app/install_space.cpp
+++ b/src/app/install_space.cpp
@@ -1,5 +1,7 @@
 #include "install_space.hpp"
 
+#include "nx_file_types.hpp"
+
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
@@ -38,9 +40,11 @@ std::vector<uint8_t> defaultInstallSelection(
     mask.reserve(preview.files.size());
     bool allSelected = true;
     for (const TorrentPreview::File& file : preview.files) {
-        const uint8_t action = file.package
-            ? static_cast<uint8_t>(FileAction::Install)
-            : static_cast<uint8_t>(FileAction::Skip);
+        uint8_t action = static_cast<uint8_t>(FileAction::Skip);
+        if (file.package)
+            action = static_cast<uint8_t>(FileAction::Install);
+        else if (!file.cartridge && isPortPayloadName(file.path))
+            action = static_cast<uint8_t>(FileAction::Download);
         mask.push_back(action);
         allSelected = allSelected &&
                       action != static_cast<uint8_t>(FileAction::Skip);

--- a/src/app/nx_file_types.hpp
+++ b/src/app/nx_file_types.hpp
@@ -48,5 +48,39 @@ inline bool isPortArchiveName(const std::string& path) {
     return lower == "switch.7z" || lower == "switch.zip";
 }
 
-} // namespace pipensx
+inline bool hasNroExtension(const std::string& path) {
+    return hasFileExtension(path, ".nro");
+}
 
+inline bool isSwitchPathComponent(const std::string& value) {
+    const char expected[] = "switch";
+    if (value.size() != 6)
+        return false;
+    for (size_t i = 0; i < 6; ++i)
+        if (static_cast<char>(std::tolower(
+                static_cast<unsigned char>(value[i]))) != expected[i])
+            return false;
+    return true;
+}
+
+inline bool pathContainsSwitchComponent(const std::string& path) {
+    size_t start = 0;
+    while (start < path.size()) {
+        const size_t slash = path.find_first_of("/\\", start);
+        const std::string component = path.substr(
+            start, slash == std::string::npos ? std::string::npos
+                                               : slash - start);
+        if (isSwitchPathComponent(component))
+            return true;
+        if (slash == std::string::npos)
+            break;
+        start = slash + 1;
+    }
+    return false;
+}
+
+inline bool isPortPayloadName(const std::string& path) {
+    return isPortArchiveName(path) || pathContainsSwitchComponent(path);
+}
+
+} // namespace pipensx

--- a/src/app/switch_deploy.cpp
+++ b/src/app/switch_deploy.cpp
@@ -113,11 +113,6 @@ bool validNro(const std::string& path) {
     return ok && magic == kNroMagic;
 }
 
-bool hasNroExtension(const std::string& path) {
-    const std::string lower = lowerAscii(path);
-    return lower.size() >= 4 && lower.compare(lower.size() - 4, 4, ".nro") == 0;
-}
-
 bool destinationParentsSafe(const std::string& root,
                             const std::string& relative) {
     struct stat rootStat {};

--- a/src/ui/detail/game_detail.hpp
+++ b/src/ui/detail/game_detail.hpp
@@ -914,8 +914,14 @@ private:
                     import.fileSelection.reserve(info.files.size());
                     for (const DebridFile& file : info.files) {
                         const bool package = isPackageName(file.path);
-                        import.fileSelection.push_back(static_cast<uint8_t>(
-                            package ? FileAction::Install : FileAction::Skip));
+                        FileAction action = FileAction::Skip;
+                        if (package)
+                            action = FileAction::Install;
+                        else if (!isCartridgeName(file.path) &&
+                                 isPortPayloadName(file.path))
+                            action = FileAction::Download;
+                        import.fileSelection.push_back(
+                            static_cast<uint8_t>(action));
                         import.packageCount += package ? 1 : 0;
                     }
                 }
@@ -950,16 +956,12 @@ private:
         }
 
         // Metadata is in: swap the catalog-declared size on the meter for the
-        // real one. Mirrors the one-tap selection (install the packages, skip
-        // the extras); a release with no packages is sized as a plain download.
-        std::vector<uint8_t> actions;
-        actions.reserve(preview.files.size());
-        for (const auto& file : preview.files) {
-            FileAction action = preview.packageCount == 0
-                ? FileAction::Download
-                : (file.package ? FileAction::Install : FileAction::Skip);
-            actions.push_back(static_cast<uint8_t>(action));
-        }
+        // real one. Mirrors the one-tap selection: install packages, keep port
+        // payloads downloadable, and skip unrelated extras.
+        std::vector<uint8_t> actions = pipensx::defaultInstallSelection(
+            preview, TransferMode::StreamInstall,
+            preview.packageCount == 0 ? StreamSelection::AllFiles
+                                      : StreamSelection::PackagesOnly);
         const auto sized = pipensx::estimateInstallSpace(
             preview, actions, TransferMode::StreamInstall);
         if (!preview.files.empty() && !sized.overflow) {
@@ -988,15 +990,18 @@ private:
             return;
         }
 
-        // Packages present. Install them silently. On a mixed release (anything
-        // that is not an install package) auto-select packages only; on a clean
-        // package-only release an empty mask means "all files".
+        // Packages present. Install them silently and include known homebrew
+        // port payloads so Copy to /switch can run after the download settles.
         uint32_t extras = preview.fileCount - preview.packageCount;
-        std::vector<uint8_t> mask;
-        if (extras > 0) {
-            mask.reserve(preview.files.size());
-            for (const auto& file : preview.files)
-                mask.push_back(file.package ? 1 : 0);
+        std::vector<uint8_t> mask = pipensx::defaultInstallSelection(
+            preview, TransferMode::StreamInstall,
+            extras > 0 ? StreamSelection::PackagesOnly
+                       : StreamSelection::AllFiles);
+        bool skippedExtras = false;
+        for (size_t i = 0; i < preview.files.size() && i < mask.size(); ++i) {
+            skippedExtras = skippedExtras ||
+                (!preview.files[i].package &&
+                 mask[i] == static_cast<uint8_t>(FileAction::Skip));
         }
 
         std::string id;
@@ -1007,7 +1012,7 @@ private:
         if (manager_->importTorrent(path, TransferMode::StreamInstall, mask,
                                     id, err, initialPeers)) {
             log_msg("[catalog] imported torrent %s\n", id.c_str());
-            if (extras > 0) {
+            if (skippedExtras) {
                 statusLabel_->setText(
                     tr("pipensx/detail/installing_extras_skipped_hint"));
                 brls::Application::notify(

--- a/src/ui/detail/torrent_selection.hpp
+++ b/src/ui/detail/torrent_selection.hpp
@@ -552,6 +552,10 @@ private:
             entry.cartridge = file.cartridge;
             if (preferred_ == TransferMode::StreamInstall && file.package) {
                 entry.action = FileAction::Install;
+            } else if (preferred_ == TransferMode::StreamInstall &&
+                       initialSelection_ == StreamSelection::PackagesOnly &&
+                       !file.cartridge && isPortPayloadName(file.path)) {
+                entry.action = FileAction::Download;
             } else if (initialSelection_ == StreamSelection::AllFiles ||
                        preferred_ != TransferMode::StreamInstall) {
                 entry.action = FileAction::Download;

--- a/tests/test_install_space.cpp
+++ b/tests/test_install_space.cpp
@@ -49,6 +49,47 @@ int main() {
 
     {
         TorrentPreview preview;
+        preview.multi = true;
+        preview.name = "port-bundle";
+        preview.files = {
+            {"game.nsp", 1024, true, false, false},
+            {"switch/game/game.nro", 256, false, false, false},
+            {"switch/game/config.json", 128, false, false, false},
+            {"readme.txt", 64, false, false, false},
+        };
+        std::vector<uint8_t> selection = defaultInstallSelection(
+            preview, TransferMode::StreamInstall,
+            StreamSelection::PackagesOnly);
+        assert((selection == std::vector<uint8_t>{
+            static_cast<uint8_t>(FileAction::Install),
+            static_cast<uint8_t>(FileAction::Download),
+            static_cast<uint8_t>(FileAction::Download),
+            static_cast<uint8_t>(FileAction::Skip),
+        }));
+
+        InstallSpaceEstimate estimate = estimateInstallSpace(
+            preview, selection, TransferMode::StreamInstall);
+        assert(estimate.selectedFiles == 3);
+        assert(estimate.packageFiles == 1);
+        assert(estimate.downloadBytes == 384);
+        assert(estimate.packageBytes == 1024);
+        assert(estimate.requiredBytes == 1408);
+    }
+
+    {
+        TorrentPreview preview;
+        preview.files = {
+            {"game.nsp", 1024, true, false, false},
+            {"switch.7z", 512, false, false, false},
+        };
+        std::vector<uint8_t> selection = defaultInstallSelection(
+            preview, TransferMode::StreamInstall,
+            StreamSelection::PackagesOnly);
+        assert(selection.empty());
+    }
+
+    {
+        TorrentPreview preview;
         preview.files = {
             {"game.nsp", 1024, true, false, false},
             {"readme.txt", 256, false, false, false},


### PR DESCRIPTION
## Summary
- Keep homebrew port payloads selected when stream-installing package torrents.
- Treat files under a `switch/` path and `switch.7z` / `switch.zip` as downloadable payloads instead of skipped extras.
- Reuse the shared file-type helpers in deploy detection and cover the selection behavior in install-space tests.

Fixes #6.

## Verification
- `scripts/check_i18n.py`
- `make golden`
- `make -f Makefile.pc build-pc/tests/test_install_space && ./build-pc/tests/test_install_space`
- `make -f Makefile.pc build-pc/tests/test_switch_deploy && ./build-pc/tests/test_switch_deploy`

## Note
- `make -f Makefile.pc test` passed through the suite until `test_manager`, which failed on the known network/DHT-sensitive fast-resume assertion `armed`.