### PR TITLE
fix(ui): disable marquee at rest in list cells, enable on focus

### DIFF
--- a/src/ui/catalog/batch_install.hpp
+++ b/src/ui/catalog/batch_install.hpp
@@ -44,9 +44,11 @@ public:
         body->setJustifyContent(brls::JustifyContent::CENTER);
         title_ = new brls::Label();
         title_->setSingleLine(true);
+        title_->setAutoAnimate(false);
         title_->setFontSize(18);
         meta_ = new brls::Label();
         meta_->setSingleLine(true);
+        meta_->setAutoAnimate(false);
         meta_->setFontSize(14);
         meta_->setMarginTop(4);
         meta_->setTextColor(theme::textTertiary());
@@ -77,6 +79,16 @@ public:
         title_->setTextColor(theme::textPrimary());
         title_->setText(failure.entry.title);
         meta_->setText(failure.error);
+    }
+
+    void onFocusGained() override {
+        brls::RecyclerCell::onFocusGained();
+        title_->setAnimated(true);
+    }
+
+    void onFocusLost() override {
+        brls::RecyclerCell::onFocusLost();
+        title_->setAnimated(false);
     }
 
 private:

--- a/src/ui/catalog/catalog_grid.hpp
+++ b/src/ui/catalog/catalog_grid.hpp
@@ -574,10 +574,12 @@ public:
         kicker_->setText(tr("pipensx/catalog/featured"));
         title_ = new brls::Label();
         title_->setSingleLine(true);
+        title_->setAutoAnimate(false);
         title_->setFontSize(theme::kFontHeading);
         title_->setMarginTop(2);
         sub_ = new brls::Label();
         sub_->setSingleLine(true);
+        sub_->setAutoAnimate(false);
         sub_->setFontSize(theme::kFontCaption);
         sub_->setTextColor(theme::textTertiary());
         sub_->setMarginTop(2);
@@ -608,6 +610,16 @@ public:
         sub_->setTextColor(info.subIsBadge ? theme::accent()
                                            : theme::textTertiary());
         setArtworkUrl(image_, service, imageUrl, currentUrl_, imageState_);
+    }
+
+    void onFocusGained() override {
+        brls::Box::onFocusGained();
+        title_->setAnimated(true);
+    }
+
+    void onFocusLost() override {
+        brls::Box::onFocusLost();
+        title_->setAnimated(false);
     }
 
     int entryIndex() const { return entryIndex_; }

--- a/src/ui/detail/torrent_selection.hpp
+++ b/src/ui/detail/torrent_selection.hpp
@@ -84,12 +84,14 @@ public:
 
         directory_ = new brls::Label();
         directory_->setSingleLine(true);
+        directory_->setAutoAnimate(false);
         directory_->setFontSize(18);
         directory_->setTextColor(theme::textTertiary());
         pathRow->addView(directory_);
 
         name_ = new brls::Label();
         name_->setSingleLine(true);
+        name_->setAutoAnimate(false);
         name_->setFontSize(18);
         name_->setGrow(1);
         pathRow->addView(name_);
@@ -97,6 +99,7 @@ public:
 
         meta_ = new brls::Label();
         meta_->setSingleLine(true);
+        meta_->setAutoAnimate(false);
         meta_->setFontSize(14);
         meta_->setMarginTop(4);
         meta_->setTextColor(theme::textTertiary());
@@ -107,6 +110,7 @@ public:
         // an auto-width label would also spill under the scroll bar.
         size_ = new brls::Label();
         size_->setSingleLine(true);
+        size_->setAutoAnimate(false);
         size_->setFontSize(17);
         size_->setWidth(110);
         size_->setMarginLeft(16);
@@ -159,6 +163,16 @@ public:
         name_->setTextColor(theme::textDisabled());
         meta_->setText("");
         size_->setText("");
+    }
+
+    void onFocusGained() override {
+        brls::RecyclerCell::onFocusGained();
+        name_->setAnimated(true);
+    }
+
+    void onFocusLost() override {
+        brls::RecyclerCell::onFocusLost();
+        name_->setAnimated(false);
     }
 
 private:

--- a/src/ui/downloads/download_cell.hpp
+++ b/src/ui/downloads/download_cell.hpp
@@ -55,10 +55,12 @@ public:
         top->setAlignItems(brls::AlignItems::CENTER);
         title_ = new brls::Label();
         title_->setSingleLine(true);
+        title_->setAutoAnimate(false);
         title_->setFontSize(22);
         title_->setGrow(1);
         status_ = new brls::Label();
         status_->setSingleLine(true);
+        status_->setAutoAnimate(false);
         status_->setFontSize(17);
         status_->setTextColor(theme::accent());
         top->addView(title_);
@@ -66,6 +68,7 @@ public:
 
         meta_ = new brls::Label();
         meta_->setSingleLine(true);
+        meta_->setAutoAnimate(false);
         meta_->setFontSize(16);
         meta_->setMarginTop(6);
         meta_->setMarginBottom(9);
@@ -166,6 +169,16 @@ public:
                 iconUrl = found->iconUrl;
         }
         setArtworkUrl(image_, service, iconUrl, currentIconUrl_, imageState_);
+    }
+
+    void onFocusGained() override {
+        brls::RecyclerCell::onFocusGained();
+        title_->setAnimated(true);
+    }
+
+    void onFocusLost() override {
+        brls::RecyclerCell::onFocusLost();
+        title_->setAnimated(false);
     }
 
 private:

--- a/src/ui/downloads/file_picker.hpp
+++ b/src/ui/downloads/file_picker.hpp
@@ -45,6 +45,7 @@ public:
         setPadding(12, 24, 12, 24);
         label_ = new brls::Label();
         label_->setSingleLine(true);
+        label_->setAutoAnimate(false);
         label_->setFontSize(21);
         addView(label_);
     }
@@ -52,6 +53,14 @@ public:
         label_->setText(entry.directory
                             ? tr("pipensx/picker/folder", entry.name)
                                         : entry.name);
+    }
+    void onFocusGained() override {
+        brls::RecyclerCell::onFocusGained();
+        label_->setAnimated(true);
+    }
+    void onFocusLost() override {
+        brls::RecyclerCell::onFocusLost();
+        label_->setAnimated(false);
     }
 private:
     brls::Label* label_;

--- a/src/ui/downloads/file_picker.hpp
+++ b/src/ui/downloads/file_picker.hpp
@@ -58,6 +58,7 @@ public:
         brls::RecyclerCell::onFocusGained();
         label_->setAnimated(true);
     }
+
     void onFocusLost() override {
         brls::RecyclerCell::onFocusLost();
         label_->setAnimated(false);

--- a/src/ui/downloads/task_files_activity.hpp
+++ b/src/ui/downloads/task_files_activity.hpp
@@ -70,10 +70,12 @@ public:
         setAxis(brls::Axis::COLUMN);
         path_ = new brls::Label();
         path_->setSingleLine(true);
+        path_->setAutoAnimate(false);
         path_->setFontSize(18);
         addView(path_);
         meta_ = new brls::Label();
         meta_->setSingleLine(true);
+        meta_->setAutoAnimate(false);
         meta_->setFontSize(14);
         meta_->setMarginTop(4);
         meta_->setTextColor(theme::textTertiary());
@@ -87,6 +89,16 @@ public:
         path_->setTextColor(file.state == TaskFileState::Missing ||
                                     file.state == TaskFileState::Unsafe
                                 ? theme::error() : theme::textPrimary());
+    }
+
+    void onFocusGained() override {
+        brls::RecyclerCell::onFocusGained();
+        path_->setAnimated(true);
+    }
+
+    void onFocusLost() override {
+        brls::RecyclerCell::onFocusLost();
+        path_->setAnimated(false);
     }
 
 private:

--- a/src/ui/downloads/task_files_activity.hpp
+++ b/src/ui/downloads/task_files_activity.hpp
@@ -319,10 +319,12 @@ public:
         setAxis(brls::Axis::COLUMN);
         destination_ = new brls::Label();
         destination_->setSingleLine(true);
+        destination_->setAutoAnimate(false);
         destination_->setFontSize(18);
         addView(destination_);
         state_ = new brls::Label();
         state_->setSingleLine(true);
+        state_->setAutoAnimate(false);
         state_->setFontSize(13);
         state_->setMarginTop(3);
         addView(state_);
@@ -339,6 +341,16 @@ public:
         state_->setTextColor(entry.state ==
                                      SwitchDeployEntryState::ExistingConflict
                                  ? theme::error() : theme::textTertiary());
+    }
+
+    void onFocusGained() override {
+        brls::Box::onFocusGained();
+        destination_->setAnimated(true);
+    }
+
+    void onFocusLost() override {
+        brls::Box::onFocusLost();
+        destination_->setAnimated(false);
     }
 
 private:

--- a/src/ui/installed/installed_view.hpp
+++ b/src/ui/installed/installed_view.hpp
@@ -48,9 +48,11 @@ public:
         labels->setGrow(1);
         title_ = new brls::Label();
         title_->setSingleLine(true);
+        title_->setAutoAnimate(false);
         title_->setFontSize(21);
         subtitle_ = new brls::Label();
         subtitle_->setSingleLine(true);
+        subtitle_->setAutoAnimate(false);
         subtitle_->setFontSize(15);
         subtitle_->setMarginTop(6);
         subtitle_->setTextColor(theme::textTertiary());
@@ -61,6 +63,7 @@ public:
         // Update-state chip (Q10 colours): right-aligned coloured label.
         chip_ = new brls::Label();
         chip_->setSingleLine(true);
+        chip_->setAutoAnimate(false);
         chip_->setFontSize(13);
         chip_->setMarginLeft(12);
         chip_->setShrink(0.0f);
@@ -141,6 +144,16 @@ public:
             chip_->setTextColor(theme::textTertiary());
             break;
         }
+    }
+
+    void onFocusGained() override {
+        brls::RecyclerCell::onFocusGained();
+        title_->setAnimated(true);
+    }
+
+    void onFocusLost() override {
+        brls::RecyclerCell::onFocusLost();
+        title_->setAnimated(false);
     }
 
 private:


### PR DESCRIPTION
## Summary

Disables the marquee at rest in list cells and enables it only while a row is focused. Fixes #18.

### Problem
Borealis `Label::autoAnimate` defaults to `true`, so all `setSingleLine(true)` labels in a focused cell scrolled at once — visual noise and needless per-frame text relayout.

### Fix
Applied the existing `GameCard` pattern (`catalog_grid.hpp`): `setAutoAnimate(false)` on every single-line label, then `setAnimated(true)` / `setAnimated(false)` in `onFocusGained` / `onFocusLost` on the primary label only.

- `DownloadCell` — title; status/meta static
- `InstalledCell` — title; subtitle/chip static
- `TaskFileCell` — path; meta static
- `FileCell` — label
- `BatchInstallCell` — title; meta static
- `TorrentSelectionCell` — filename; directory/meta/size static
- `DeployPreviewRow` — destination; state static
- `HeroCard` — title; sub static

`ShelfCell` titles are not single-line; shelf cards already use `GameCard`.

## Golden
Pixel deltas sit within the existing per-screen focus budget, so `make golden` passes without a re-baseline.

## Verification
- `make golden` — OK (all screens within budget, all behaviour checks pass)
- `DEVKITPRO=/opt/devkitpro make switch` — OK (original commit)
- `make pc` — OK (original commit)