### PR TITLE
Speed up debrid HTTPS downloads

### DIFF
--- a/src/app/curl_https.hpp
+++ b/src/app/curl_https.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <curl/curl.h>
+#include <sys/socket.h>
 
 #include <string>
 
@@ -18,6 +19,25 @@ inline void curlPinHttpsOnly(CURL* curl) {
     curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
     curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTPS);
 #endif
+}
+
+// Borealis boots the Switch socket service with tiny default buffers;
+// a larger receive window is what keeps long HTTPS transfers off the
+// kilobytes-per-second floor. bsd:u silently clamps SO_RCVBUF at 256 KiB.
+inline int curlEnlargeReceiveBuffer(void*, curl_socket_t socket,
+                                    curlsocktype purpose) {
+    if (purpose == CURLSOCKTYPE_IPCXN) {
+        int size = 256 * 1024;
+        setsockopt(socket, SOL_SOCKET, SO_RCVBUF,
+                   reinterpret_cast<const char*>(&size), sizeof(size));
+    }
+    return CURL_SOCKOPT_OK;
+}
+
+inline void curlTuneDownloadSocket(CURL* curl) {
+    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+    curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, 256L * 1024L);
+    curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, curlEnlargeReceiveBuffer);
 }
 
 // Same guarantee for a URL that may legitimately be plain HTTP — a TorrServer

--- a/src/app/debrid_transfer.cpp
+++ b/src/app/debrid_transfer.cpp
@@ -15,6 +15,7 @@ extern "C" {
 }
 
 #include <cerrno>
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -22,6 +23,7 @@ extern "C" {
 #include <cstring>
 #include <deque>
 #include <fstream>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <sys/stat.h>
@@ -248,20 +250,36 @@ bool sleepSlices(const std::function<bool()>& shouldStop, int totalMs) {
     return true;
 }
 
+constexpr size_t kInstallBatchBytes = 1u << 20;
+constexpr unsigned kRangeWorkers = 4;
+constexpr uint64_t kRangeSegmentBytes = 4ull << 20;
+
 struct CurlSink {
     const std::function<bool(const uint8_t*, size_t)>* sink;
     const std::function<bool()>* cancelled;
+    CURL* curl = nullptr;
+    bool ranged = false;
     bool aborted = false;
     // Which side gave up matters: the sink refusing bytes is an install-side
     // failure, and blaming the network for it sends everyone hunting in the
     // wrong place.
     bool sinkRefused = false;
+    bool rangeIgnored = false;
     uint64_t received = 0;
 };
 
 size_t curlWrite(char* ptr, size_t size, size_t nmemb, void* userdata) {
     CurlSink* c = static_cast<CurlSink*>(userdata);
     size_t total = size * nmemb;
+    if (c->ranged && c->curl) {
+        long status = 0;
+        curl_easy_getinfo(c->curl, CURLINFO_RESPONSE_CODE, &status);
+        if (status == 200) {
+            c->rangeIgnored = true;
+            c->aborted = true;
+            return 0;
+        }
+    }
     if ((*c->cancelled)()) {
         c->aborted = true;
         return 0;
@@ -276,7 +294,7 @@ size_t curlWrite(char* ptr, size_t size, size_t nmemb, void* userdata) {
 }
 
 RangeFetcher curlRangeFetcher() {
-    return [](const std::string& url, uint64_t offset,
+    return [](const std::string& url, uint64_t offset, uint64_t endExclusive,
               const std::function<bool(const uint8_t*, size_t)>& sink,
               const std::function<bool()>& cancelled,
               std::string& error) -> bool {
@@ -297,10 +315,22 @@ RangeFetcher curlRangeFetcher() {
             error = "Unable to initialize network transfer.";
             return false;
         }
-        CurlSink state{&sink, &cancelled, false};
+        CurlSink state;
+        state.sink = &sink;
+        state.cancelled = &cancelled;
+        state.curl = curl;
+        state.ranged = endExclusive != 0;
         curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-        curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE,
-                         static_cast<curl_off_t>(offset));
+        if (state.ranged) {
+            char range[80];
+            std::snprintf(range, sizeof(range), "%llu-%llu",
+                          (unsigned long long)offset,
+                          (unsigned long long)(endExclusive - 1));
+            curl_easy_setopt(curl, CURLOPT_RANGE, range);
+        } else {
+            curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE,
+                             static_cast<curl_off_t>(offset));
+        }
         curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
         curlPinScheme(curl, url);
         curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
@@ -308,6 +338,7 @@ RangeFetcher curlRangeFetcher() {
         curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
         curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 60L);
         curlApplyTrustedSsl(curl);
+        curlTuneDownloadSocket(curl);
         curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlWrite);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &state);
@@ -315,6 +346,10 @@ RangeFetcher curlRangeFetcher() {
         long httpStatus = 0;
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpStatus);
         curl_easy_cleanup(curl);
+        if (state.rangeIgnored || (httpStatus == 200 && state.ranged)) {
+            error = kDebridRangeNotSupported;
+            return false;
+        }
         if (rc != CURLE_OK || state.aborted)
             log_msg("[debrid] fetch ended rc=%d (%s) http=%ld got=%llu%s\n",
                     static_cast<int>(rc), curl_easy_strerror(rc), httpStatus,
@@ -326,6 +361,10 @@ RangeFetcher curlRangeFetcher() {
             error = state.sinkRefused
                 ? "The installer rejected the downloaded data."
                 : "The download stream was interrupted.";
+            return false;
+        }
+        if (state.ranged && httpStatus != 206) {
+            error = kDebridRangeNotSupported;
             return false;
         }
         if (rc != CURLE_OK) {
@@ -537,22 +576,178 @@ Step pollUntilReady(RunContext& ctx) {
     }
 }
 
+bool shouldEmitProgress(Clock::time_point& lastEmit) {
+    Clock::time_point now = Clock::now();
+    if (lastEmit == Clock::time_point::min() ||
+        std::chrono::duration_cast<std::chrono::milliseconds>(now - lastEmit)
+                .count() >= 250) {
+        lastEmit = now;
+        return true;
+    }
+    return false;
+}
+
+// Pull [offset, totalBytes) through the injected fetcher. Several Range
+// workers fill a reorder map; only the next sequential offset is pushed to
+// sink. A 206-less CDN falls back to one stream from the committed offset.
+bool fetchOrdered(const RangeFetcher& fetcher, const std::string& url,
+                  uint64_t offset, uint64_t totalBytes,
+                  size_t maxInFlightBytes,
+                  const std::function<bool(const uint8_t*, size_t)>& sink,
+                  const std::function<bool()>& cancelled, std::string& error) {
+    if (offset > totalBytes) {
+        error = "range past end";
+        return false;
+    }
+    const uint64_t remaining = totalBytes - offset;
+    size_t maxInFlight = kRangeSegmentBytes
+        ? std::max<size_t>(1, maxInFlightBytes / kRangeSegmentBytes)
+        : 1;
+    if (maxInFlight > kRangeWorkers)
+        maxInFlight = kRangeWorkers;
+    if (remaining < 2 * kRangeSegmentBytes || maxInFlight < 2)
+        return fetcher(url, offset, 0, sink, cancelled, error);
+
+    std::mutex mu;
+    std::condition_variable cv;
+    std::map<uint64_t, std::vector<uint8_t>> ready;
+    uint64_t nextToAssign = offset;
+    uint64_t nextToEmit = offset;
+    unsigned inFlight = 0;
+    bool failed = false;
+    bool rangeIgnored = false;
+    bool stopWorkers = false;
+    std::string workerError;
+
+    auto takeJob = [&](uint64_t& start, uint64_t& end) -> bool {
+        std::unique_lock<std::mutex> lock(mu);
+        cv.wait(lock, [&] {
+            if (stopWorkers || cancelled())
+                return true;
+            if (nextToAssign >= totalBytes)
+                return true;
+            return (inFlight + ready.size()) < maxInFlight;
+        });
+        if (stopWorkers || cancelled() || nextToAssign >= totalBytes)
+            return false;
+        start = nextToAssign;
+        end = std::min(totalBytes, start + kRangeSegmentBytes);
+        nextToAssign = end;
+        ++inFlight;
+        return true;
+    };
+
+    std::vector<std::thread> workers;
+    workers.reserve(maxInFlight);
+    for (size_t i = 0; i < maxInFlight; ++i) {
+        workers.emplace_back([&] {
+            uint64_t start = 0;
+            uint64_t end = 0;
+            while (takeJob(start, end)) {
+                std::vector<uint8_t> buf;
+                buf.reserve(static_cast<size_t>(end - start));
+                auto collect = [&](const uint8_t* data, size_t n) -> bool {
+                    buf.insert(buf.end(), data, data + n);
+                    return !cancelled();
+                };
+                std::string err;
+                auto workerCancel = [&] {
+                    std::lock_guard<std::mutex> lock(mu);
+                    return stopWorkers || cancelled();
+                };
+                bool ok = fetcher(url, start, end, collect, workerCancel, err);
+                if (ok && buf.size() != static_cast<size_t>(end - start)) {
+                    ok = false;
+                    err = "short range";
+                }
+                {
+                    std::lock_guard<std::mutex> lock(mu);
+                    --inFlight;
+                    if (!ok) {
+                        if (err == kDebridRangeNotSupported)
+                            rangeIgnored = true;
+                        else {
+                            failed = true;
+                            if (workerError.empty())
+                                workerError = err;
+                        }
+                        stopWorkers = true;
+                    } else {
+                        ready.emplace(start, std::move(buf));
+                    }
+                }
+                cv.notify_all();
+            }
+        });
+    }
+
+    bool sinkOk = true;
+    while (nextToEmit < totalBytes) {
+        std::vector<uint8_t> chunk;
+        {
+            std::unique_lock<std::mutex> lock(mu);
+            cv.wait(lock, [&] {
+                return cancelled() || failed || rangeIgnored || stopWorkers ||
+                       ready.count(nextToEmit);
+            });
+            if (cancelled() || failed || rangeIgnored ||
+                (stopWorkers && !ready.count(nextToEmit)))
+                break;
+            auto it = ready.find(nextToEmit);
+            chunk = std::move(it->second);
+            ready.erase(it);
+        }
+        if (!sink(chunk.data(), chunk.size())) {
+            sinkOk = false;
+            std::lock_guard<std::mutex> lock(mu);
+            failed = true;
+            stopWorkers = true;
+            if (workerError.empty())
+                workerError = "The installer rejected the downloaded data.";
+            cv.notify_all();
+            break;
+        }
+        nextToEmit += chunk.size();
+        cv.notify_all();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        stopWorkers = true;
+    }
+    cv.notify_all();
+    for (std::thread& t : workers)
+        if (t.joinable())
+            t.join();
+
+    if (cancelled())
+        return false;
+    if (rangeIgnored)
+        return fetcher(url, nextToEmit, 0, sink, cancelled, error);
+    if (!sinkOk || failed) {
+        error = workerError.empty() ? "Download failed." : workerError;
+        return false;
+    }
+    return nextToEmit == totalBytes;
+}
+
 Step fetchAppend(RunContext& ctx, const std::string& url,
                  const std::string& localPath, uint64_t offset,
-                 uint64_t baseCompleted) {
-    std::ofstream out(localPath, std::ios::binary | std::ios::app);
+                 uint64_t fileBytes, uint64_t baseCompleted) {
+    FILE* out = std::fopen(localPath.c_str(), "ab");
     if (!out) {
         ctx.error = "Unable to open the download file for writing.";
         return Step::Failed;
     }
+    std::vector<char> writeBuffer(kInstallBatchBytes);
+    std::setvbuf(out, writeBuffer.data(), _IOFBF, writeBuffer.size());
     Clock::time_point windowStart = Clock::now();
+    Clock::time_point lastEmit = Clock::time_point::min();
     uint64_t windowBytes = 0;
     uint64_t written = 0;
     uint64_t speed = 0;
     auto sink = [&](const uint8_t* data, size_t n) -> bool {
-        out.write(reinterpret_cast<const char*>(data),
-                  static_cast<std::streamsize>(n));
-        if (!out)
+        if (std::fwrite(data, 1, n, out) != n)
             return false;
         written += n;
         windowBytes += n;
@@ -564,6 +759,8 @@ Step fetchAppend(RunContext& ctx, const std::string& url,
             windowStart = now;
             windowBytes = 0;
         }
+        if (!shouldEmitProgress(lastEmit))
+            return true;
         DebridProgress p;
         p.status = DownloadStatus::Downloading;
         p.completedBytes = baseCompleted + offset + written;
@@ -574,9 +771,13 @@ Step fetchAppend(RunContext& ctx, const std::string& url,
         return true;
     };
     std::string err;
-    bool ok = ctx.fetcher(url, offset, sink, *ctx.shouldStop, err);
-    out.flush();
-    out.close();
+    StreamRamBudget budget = detectStreamRamBudget(1 * 1024 * 1024);
+    const size_t maximumBuffered = budget.valid
+        ? budget.maxBufferedBytes : 64 * 1024 * 1024;
+    bool ok = fetchOrdered(ctx.fetcher, url, offset, fileBytes,
+                           maximumBuffered / 2, sink, *ctx.shouldStop, err);
+    std::fflush(out);
+    std::fclose(out);
     if (!ok) {
         if (ctx.stop())
             return Step::Stopped;
@@ -624,7 +825,8 @@ Step downloadPlainFile(RunContext& ctx, size_t kthSelected,
     for (int attempt = 0; attempt < 2; ++attempt) {
         uint64_t offset = 0;
         statSize(localPath, offset);
-        Step s = fetchAppend(ctx, url, localPath, offset, ctx.completedSoFar);
+        Step s = fetchAppend(ctx, url, localPath, offset, file.bytes,
+                             ctx.completedSoFar);
         if (s == Step::Ok)
             break;
         if (s == Step::Stopped)
@@ -676,22 +878,26 @@ install::PackageCallbacks makeCallbacks(RunContext& ctx,
             ctx.error = backend->error();
         return ok;
     };
-    callbacks.writeFile = [backend, &ctx, displayName, &pacer](
+    callbacks.writeFile = [backend, &ctx, displayName, &pacer,
+                           lastEmit = std::make_shared<Clock::time_point>(
+                               Clock::time_point::min())](
                               const uint8_t* data, size_t size) {
         if (!pacer.waitForWrite(size, [&ctx] { return ctx.stop(); }))
             return false;
         bool ok = backend->writeFile(data, size);
         if (ok) {
-            DebridProgress p;
-            p.status = DownloadStatus::Installing;
-            p.totalBytes = ctx.totalBytes;
-            p.completedBytes = ctx.completedSoFar +
-                               ctx.packageDownloadedBytes.load();
-            p.packagesInstalled = ctx.packagesInstalled;
-            p.currentPackage = displayName;
-            p.installedBytes = backend->installedBytes();
-            p.installTotalBytes = backend->expectedBytes();
-            ctx.emit(p);
+            if (shouldEmitProgress(*lastEmit)) {
+                DebridProgress p;
+                p.status = DownloadStatus::Installing;
+                p.totalBytes = ctx.totalBytes;
+                p.completedBytes = ctx.completedSoFar +
+                                   ctx.packageDownloadedBytes.load();
+                p.packagesInstalled = ctx.packagesInstalled;
+                p.currentPackage = displayName;
+                p.installedBytes = backend->installedBytes();
+                p.installTotalBytes = backend->expectedBytes();
+                ctx.emit(p);
+            }
         } else {
             ctx.error = backend->error();
         }
@@ -734,21 +940,47 @@ Step attemptStreamInstall(RunContext& ctx, const DebridFile& file,
             ctx.packageDownloadedBytes.fetch_add(n);
             return queue.push(data, n);
         };
-        fetchOk = ctx.fetcher(url, 0, sink, *ctx.shouldStop, fetchError);
+        fetchOk = fetchOrdered(ctx.fetcher, url, 0, file.bytes,
+                               maximumBuffered / 2, sink, *ctx.shouldStop,
+                               fetchError);
         queue.finish();
     });
 
     bool streamOk = true;
     std::vector<uint8_t> chunk;
-    while (queue.pop(chunk)) {
-        if (!stream.write(chunk.data(), chunk.size())) {
+    std::vector<uint8_t> batch;
+    batch.reserve(kInstallBatchBytes);
+    auto flushBatch = [&]() -> bool {
+        if (batch.empty())
+            return true;
+        if (!stream.write(batch.data(), batch.size())) {
             streamOk = false;
             queue.stop();
-            break;
+            batch.clear();
+            return false;
         }
         pacer.observeConsumed(stream.consumed(), backend->installedBytes(),
                               now_ms());
+        batch.clear();
+        return true;
+    };
+    while (queue.pop(chunk)) {
+        if (batch.empty() && chunk.size() >= kInstallBatchBytes) {
+            if (!stream.write(chunk.data(), chunk.size())) {
+                streamOk = false;
+                queue.stop();
+                break;
+            }
+            pacer.observeConsumed(stream.consumed(), backend->installedBytes(),
+                                  now_ms());
+        } else {
+            batch.insert(batch.end(), chunk.begin(), chunk.end());
+            if (batch.size() >= kInstallBatchBytes && !flushBatch())
+                break;
+        }
     }
+    if (streamOk)
+        flushBatch();
     queue.stop();
     producer.join();
     if (!fetchOk || !streamOk) {

--- a/src/app/debrid_transfer.hpp
+++ b/src/app/debrid_transfer.hpp
@@ -53,8 +53,15 @@ struct DebridTaskSpec {
     std::function<void(const std::vector<ResolvedFile>&)> filesResolved;
 };
 
+// Fetcher reported HTTP 200 for a bounded Range request: the server ignored
+// Range. The transfer falls back to one sequential stream from the committed
+// offset. Never treat a 200 body as a mid-file slice.
+inline constexpr const char* kDebridRangeNotSupported = "range-not-supported";
+
+// endExclusive == 0 means "to EOF" (CURLOPT_RESUME_FROM). A non-zero end is
+// exclusive and must be served as HTTP 206.
 using RangeFetcher = std::function<bool(
-    const std::string& url, uint64_t offset,
+    const std::string& url, uint64_t offset, uint64_t endExclusive,
     const std::function<bool(const uint8_t*, size_t)>& sink,
     const std::function<bool()>& cancelled,
     std::string& error)>;

--- a/src/app/update_service.cpp
+++ b/src/app/update_service.cpp
@@ -1,5 +1,6 @@
 #include "update_service.hpp"
 #include "update_transaction.h"
+#include "curl_https.hpp"
 
 #include <curl/curl.h>
 #include <borealis/extern/nlohmann/json.hpp>
@@ -13,7 +14,6 @@
 #include <cstring>
 #include <fstream>
 #include <sstream>
-#include <sys/socket.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -84,18 +84,6 @@ size_t writeFile(char* bytes, size_t size, size_t count, void* opaque) {
     return received;
 }
 
-int enlargeSocketBuffer(void*, curl_socket_t socket, curlsocktype purpose) {
-    // Borealis boots the Switch socket service with tiny default buffers;
-    // a larger receive window is what keeps the NRO download off the
-    // kilobytes-per-second floor.
-    if (purpose == CURLSOCKTYPE_IPCXN) {
-        int size = 256 * 1024;
-        setsockopt(socket, SOL_SOCKET, SO_RCVBUF,
-                   reinterpret_cast<const char*>(&size), sizeof(size));
-    }
-    return CURL_SOCKOPT_OK;
-}
-
 struct TransferProgress {
     const UpdateService::ProgressCallback* callback;
     const std::atomic<bool>* stopping;
@@ -130,8 +118,7 @@ bool configureCurl(CURL* curl, const std::string& url, TransferKind kind,
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L * 60L);
         curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1024L);
         curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 60L);
-        curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, 256L * 1024L);
-        curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, enlargeSocketBuffer);
+        curlTuneDownloadSocket(curl);
     } else {
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, 120L);
         curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);

--- a/tests/test_debrid_transfer.cpp
+++ b/tests/test_debrid_transfer.cpp
@@ -1,13 +1,17 @@
 #include "app/debrid_transfer.hpp"
 #include "app/torbox_provider.hpp"
 
+#include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <mutex>
 #include <string>
 #include <sys/stat.h>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -34,14 +38,22 @@ TorboxTransport scriptedTransport(
 }
 
 RangeFetcher memoryFetcher(const std::string& content) {
-    return [content](const std::string&, uint64_t offset,
+    return [content](const std::string&, uint64_t offset, uint64_t endExclusive,
                      const std::function<bool(const uint8_t*, size_t)>& sink,
                      const std::function<bool()>&, std::string& error) {
         if (offset > content.size()) {
             error = "range past end";
             return false;
         }
-        std::string slice = content.substr(offset);
+        uint64_t end = endExclusive == 0
+            ? content.size()
+            : std::min<uint64_t>(endExclusive, content.size());
+        if (offset > end) {
+            error = "range past end";
+            return false;
+        }
+        std::string slice = content.substr(static_cast<size_t>(offset),
+                                           static_cast<size_t>(end - offset));
         size_t half = slice.size() / 2;
         if (half && !sink(reinterpret_cast<const uint8_t*>(slice.data()),
                           half))
@@ -49,6 +61,32 @@ RangeFetcher memoryFetcher(const std::string& content) {
         if (!sink(reinterpret_cast<const uint8_t*>(slice.data()) + half,
                   slice.size() - half))
             return false;
+        return true;
+    };
+}
+
+RangeFetcher chunkedFetcher(const std::string& content, size_t piece) {
+    return [content, piece](const std::string&, uint64_t offset,
+                            uint64_t endExclusive,
+                            const std::function<bool(const uint8_t*, size_t)>&
+                                sink,
+                            const std::function<bool()>&, std::string& error) {
+        if (offset > content.size()) {
+            error = "range past end";
+            return false;
+        }
+        uint64_t end = endExclusive == 0
+            ? content.size()
+            : std::min<uint64_t>(endExclusive, content.size());
+        size_t pos = static_cast<size_t>(offset);
+        size_t stop = static_cast<size_t>(end);
+        while (pos < stop) {
+            size_t n = std::min(piece, stop - pos);
+            if (!sink(reinterpret_cast<const uint8_t*>(content.data()) + pos,
+                      n))
+                return false;
+            pos += n;
+        }
         return true;
     };
 }
@@ -173,11 +211,15 @@ void testResumeUsesOnDiskOffset() {
     }
     uint64_t seenOffset = UINT64_MAX;
     RangeFetcher fetcher = [&content, &seenOffset](
-        const std::string&, uint64_t offset,
+        const std::string&, uint64_t offset, uint64_t endExclusive,
         const std::function<bool(const uint8_t*, size_t)>& sink,
         const std::function<bool()>&, std::string&) {
         seenOffset = offset;
-        std::string slice = content.substr(offset);
+        uint64_t end = endExclusive == 0
+            ? content.size()
+            : std::min<uint64_t>(endExclusive, content.size());
+        std::string slice = content.substr(static_cast<size_t>(offset),
+                                           static_cast<size_t>(end - offset));
         return sink(reinterpret_cast<const uint8_t*>(slice.data()),
                     slice.size());
     };
@@ -290,7 +332,7 @@ void testPartialStreamFailureRetriesWithoutPacerDeadlock() {
     std::string content(nsp.begin(), nsp.end());
     int attempts = 0;
     RangeFetcher fetcher = [&content, &attempts](
-        const std::string&, uint64_t,
+        const std::string&, uint64_t, uint64_t,
         const std::function<bool(const uint8_t*, size_t)>& sink,
         const std::function<bool()>&, std::string& error) {
         ++attempts;
@@ -444,6 +486,164 @@ void testMagnetFileFallback() {
     std::puts("magnet->file fallback ok");
 }
 
+void testOutOfOrderRangesAssembleInOrder() {
+    const std::string root = "/tmp/pipensx-torbox-ooo-test";
+    system(("rm -rf " + root).c_str());
+    mkdir(root.c_str(), 0755);
+    const std::string data = root + "/data";
+    mkdir(data.c_str(), 0755);
+
+    const size_t size = 10 * 1024 * 1024;
+    std::string content(size, '\0');
+    for (size_t i = 0; i < size; ++i)
+        content[i] = static_cast<char>(i * 131u);
+
+    std::mutex mu;
+    std::vector<uint64_t> starts;
+    RangeFetcher fetcher = [&](const std::string&, uint64_t offset,
+                               uint64_t endExclusive,
+                               const std::function<bool(const uint8_t*, size_t)>&
+                                   sink,
+                               const std::function<bool()>&, std::string& error) {
+        {
+            std::lock_guard<std::mutex> lock(mu);
+            starts.push_back(offset);
+        }
+        if (endExclusive != 0 && offset == 0)
+            std::this_thread::sleep_for(std::chrono::milliseconds(80));
+        uint64_t end = endExclusive == 0
+            ? content.size()
+            : std::min<uint64_t>(endExclusive, content.size());
+        if (offset > end) {
+            error = "range past end";
+            return false;
+        }
+        return sink(reinterpret_cast<const uint8_t*>(content.data()) +
+                        static_cast<size_t>(offset),
+                    static_cast<size_t>(end - offset));
+    };
+
+    std::vector<std::pair<std::string, std::string>> script = {
+        {"mylist", infoReadyJson("Example/file.bin", content.size())},
+        {"requestdl", "{\"success\":true,\"data\":\"https://x/dl\"}"},
+    };
+    TorboxProvider provider("k", scriptedTransport(&script));
+    DebridTransfer transfer(provider, fetcher);
+
+    DebridTaskSpec spec;
+    spec.taskId = "aabbccddaabbccddaabbccddaabbccddaabbccdd";
+    spec.debridId = "42";
+    spec.dataPath = data;
+    spec.workingRoot = root;
+    spec.mode = TransferMode::DownloadOnly;
+
+    std::string debridId;
+    std::string error;
+    DebridRunResult result = transfer.run(
+        spec, [] { return false; }, [](const DebridProgress&) {}, debridId,
+        error);
+    assert(result == DebridRunResult::Finished);
+    assert(starts.size() >= 2);
+
+    std::ifstream check(data + "/file.bin", std::ios::binary);
+    std::string written((std::istreambuf_iterator<char>(check)),
+                        std::istreambuf_iterator<char>());
+    assert(written == content);
+}
+
+void testRangeIgnoredFallsBackToSequential() {
+    const std::string root = "/tmp/pipensx-torbox-range200-test";
+    system(("rm -rf " + root).c_str());
+    mkdir(root.c_str(), 0755);
+    const std::string data = root + "/data";
+    mkdir(data.c_str(), 0755);
+
+    const size_t size = 10 * 1024 * 1024;
+    std::string content(size, 'R');
+    int rangedCalls = 0;
+    int sequentialCalls = 0;
+    RangeFetcher fetcher = [&](const std::string&, uint64_t offset,
+                               uint64_t endExclusive,
+                               const std::function<bool(const uint8_t*, size_t)>&
+                                   sink,
+                               const std::function<bool()>&, std::string& error) {
+        if (endExclusive != 0) {
+            ++rangedCalls;
+            error = kDebridRangeNotSupported;
+            return false;
+        }
+        ++sequentialCalls;
+        std::string slice = content.substr(static_cast<size_t>(offset));
+        return sink(reinterpret_cast<const uint8_t*>(slice.data()),
+                    slice.size());
+    };
+
+    std::vector<std::pair<std::string, std::string>> script = {
+        {"mylist", infoReadyJson("Example/file.bin", content.size())},
+        {"requestdl", "{\"success\":true,\"data\":\"https://x/dl\"}"},
+    };
+    TorboxProvider provider("k", scriptedTransport(&script));
+    DebridTransfer transfer(provider, fetcher);
+
+    DebridTaskSpec spec;
+    spec.taskId = "aabbccddaabbccddaabbccddaabbccddaabbccdd";
+    spec.debridId = "42";
+    spec.dataPath = data;
+    spec.workingRoot = root;
+    spec.mode = TransferMode::DownloadOnly;
+
+    std::string debridId;
+    std::string error;
+    DebridRunResult result = transfer.run(
+        spec, [] { return false; }, [](const DebridProgress&) {}, debridId,
+        error);
+    assert(result == DebridRunResult::Finished);
+    assert(rangedCalls >= 1);
+    assert(sequentialCalls == 1);
+
+    std::ifstream check(data + "/file.bin", std::ios::binary);
+    std::string written((std::istreambuf_iterator<char>(check)),
+                        std::istreambuf_iterator<char>());
+    assert(written == content);
+}
+
+void testStreamInstallCoalescesTinyChunks() {
+    const std::string root = "/tmp/pipensx-torbox-coalesce-test";
+    system(("rm -rf " + root).c_str());
+    mkdir(root.c_str(), 0755);
+    const std::string data = root + "/data";
+    mkdir(data.c_str(), 0755);
+
+    std::vector<uint8_t> nca(2 * 1024 * 1024, 0x3c);
+    std::vector<uint8_t> nsp =
+        makePfs0({{"00112233445566778899aabbccddeeff.nca", nca}});
+    std::string content(nsp.begin(), nsp.end());
+
+    std::vector<std::pair<std::string, std::string>> script = {
+        {"mylist", infoReadyJson("Example/game.nsp", content.size())},
+        {"requestdl", "{\"success\":true,\"data\":\"https://x/dl\"}"},
+    };
+    TorboxProvider provider("k", scriptedTransport(&script));
+    DebridTransfer transfer(provider, chunkedFetcher(content, 4096));
+
+    DebridTaskSpec spec;
+    spec.taskId = "aabbccddaabbccddaabbccddaabbccddaabbccdd";
+    spec.debridId = "42";
+    spec.dataPath = data;
+    spec.workingRoot = root;
+    spec.mode = TransferMode::StreamInstall;
+
+    std::string debridId;
+    std::string error;
+    DebridProgress last;
+    DebridRunResult result = transfer.run(
+        spec, [] { return false; },
+        [&last](const DebridProgress& p) { last = p; }, debridId, error);
+    assert(result == DebridRunResult::Finished);
+    assert(last.status == DownloadStatus::Installed);
+    assert(last.packagesInstalled == 1);
+}
+
 void testBuildRichMagnet() {
     std::string m = buildRichMagnet(
         "0123456789abcdef0123456789abcdef01234567",
@@ -471,6 +671,9 @@ int main() {
     testSelectionPathsPicksOneFile();
     testSelectionPathsNoMatchReturnsFailed();
     testMagnetFileFallback();
+    testOutOfOrderRangesAssembleInOrder();
+    testRangeIgnoredFallsBackToSequential();
+    testStreamInstallCoalescesTinyChunks();
     testBuildRichMagnet();
     std::printf("test_debrid_transfer ok\n");
     return 0;


### PR DESCRIPTION
## Summary
- Coalesce debrid stream-install writes to 1 MiB, enlarge the curl receive window, and throttle progress emits (the on-device bottleneck from #46).
- Fetch large files as ordered HTTP Range segments on a few threads; fall back to one sequential stream if the CDN ignores Range (HTTP 200).
- Real-Debrid was already shipped; this closes the remaining speed request.

## Test plan
- [x] `make -f Makefile.pc test`
- [x] `make switch`
- [ ] Live TorBox/RD speed check on device

Fixes #46

Made with [Cursor](https://cursor.com)