### PR TITLE
fix(install): zero CNMT required_system_version in installed metas (#60)

### DIFF
--- a/Makefile.pc
+++ b/Makefile.pc
@@ -411,6 +411,10 @@ $(BUILD_DIR)/tests/test_install_journal: tests/test_install_journal.cpp \
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
 
+$(BUILD_DIR)/tests/test_content_meta: tests/test_content_meta.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) -Isrc -o $@ $^
+
 $(BUILD_DIR)/tests/test_package_coordinator: tests/test_package_coordinator.cpp \
 		$(BUILD_DIR)/src/app/stream_ram_budget.o $(BUILD_DIR)/src/app/stream_budget_arbiter.o \
 		$(BUILD_DIR)/src/app/request_gate.o $(BUILD_DIR)/src/app/install_pacer.o \

--- a/src/install/content_meta.hpp
+++ b/src/install/content_meta.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+// CNMT meta-record assembly shared by the Switch install backend and the PC
+// test suite. install_backend_switch.cpp is __SWITCH__-only, so the pure
+// byte-level logic lives here to stay unit-testable on the PC.
+
+#include <cstdint>
+#include <cstring>
+
+namespace pipensx::install {
+
+// libnx NcmContentMetaType values as they appear in a packaged CNMT header
+// (switch/services/ncm_types.h). Only Application and Patch metas carry
+// required_system_version at extended-header offset 8.
+enum : uint8_t {
+    kMetaTypeApplication = 0x80,
+    kMetaTypePatch = 0x81,
+    kMetaTypeAddOnContent = 0x82,
+};
+
+// Zeroes required_system_version (u32 at offset 8 of the extended header,
+// right after the u64 id) in an Application/Patch meta and returns the
+// original value. HOS gates title launch on this field as stored in the
+// content meta database, so a title stamped for newer firmware refuses to
+// launch with an "update required" nag even though its NCAs installed
+// byte-identically; Awoo and Tinfoil zero the same field at install. The NCA
+// payloads on storage stay untouched — only the db meta record is patched.
+// Other meta types and headers shorter than 12 bytes pass through (returns 0).
+inline uint32_t patchRequiredSystemVersion(uint8_t* extendedHeader,
+                                           uint16_t extendedHeaderSize,
+                                           uint8_t metaType) {
+    if ((metaType != kMetaTypeApplication && metaType != kMetaTypePatch) ||
+        extendedHeaderSize < sizeof(uint64_t) + sizeof(uint32_t)) {
+        return 0;
+    }
+    uint32_t original = 0;
+    std::memcpy(&original, extendedHeader + sizeof(uint64_t),
+                sizeof(original));
+    std::memset(extendedHeader + sizeof(uint64_t), 0, sizeof(original));
+    return original;
+}
+
+} // namespace pipensx::install

--- a/src/install/install_backend_switch.cpp
+++ b/src/install/install_backend_switch.cpp
@@ -1,3 +1,4 @@
+#include "install/content_meta.hpp"
 #include "install_backend.hpp"
 
 #ifdef __SWITCH__
@@ -24,6 +25,13 @@ extern "C" {
 
 namespace pipensx::install {
 namespace {
+
+// content_meta.hpp hardcodes the packaged meta type bytes; fail the build if
+// they ever drift from libnx.
+static_assert(static_cast<int>(kMetaTypeApplication) == NcmContentMetaType_Application &&
+                  static_cast<int>(kMetaTypePatch) == NcmContentMetaType_Patch &&
+                  static_cast<int>(kMetaTypeAddOnContent) == NcmContentMetaType_AddOnContent,
+              "content_meta.hpp meta type constants drifted from libnx");
 
 constexpr const char* TempRoot = "sdmc:/switch/pipensx/install-temp";
 
@@ -207,6 +215,9 @@ struct ParsedMeta {
     std::vector<NcmContentMetaInfo> metaInfos;
     std::vector<NcmContentId> deltaIds;             // content ids we skip
     uint32_t extendedDataSize = 0;                  // patch delta history size
+    // Original CNMT required_system_version, captured before it is zeroed
+    // (see patchRequiredSystemVersion). Logged for "update required" triage.
+    uint32_t requiredSystemVersion = 0;
 };
 
 bool readPackagedMeta(const std::string& ncaPath, ParsedMeta& out,
@@ -291,6 +302,13 @@ bool readPackagedMeta(const std::string& ncaPath, ParsedMeta& out,
     const uint8_t* cursor = data.data() + sizeof(out.header);
     out.extendedHeader.assign(cursor,
         cursor + out.header.extended_header_size);
+    // Issue #60: HOS enforces required_system_version from the meta database
+    // record, not from the NCA payloads. Zero it so a title stamped for
+    // newer firmware still launches; the NCAs stay byte-identical.
+    out.requiredSystemVersion = patchRequiredSystemVersion(
+        out.extendedHeader.data(),
+        out.header.extended_header_size,
+        out.header.type);
     cursor += out.header.extended_header_size;
     std::vector<NcmPackagedContentInfo> packaged(out.header.content_count);
     std::memcpy(packaged.data(), cursor,
@@ -658,9 +676,14 @@ public:
             if (!readPackagedMeta(metaNcaPath, meta, error_))
                 return false;
         }
-        log_msg("[install] CNMT parsed title=%016llx version=%u contents=%u\n",
+        log_msg("[install] CNMT parsed title=%016llx version=%u contents=%u rsv=0x%08x (%u.%u.%u)%s\n",
                 static_cast<unsigned long long>(meta.header.id),
-                meta.header.version, meta.header.content_count);
+                meta.header.version, meta.header.content_count,
+                meta.requiredSystemVersion,
+                (meta.requiredSystemVersion >> 26) & 0x3fu,
+                (meta.requiredSystemVersion >> 20) & 0x3fu,
+                (meta.requiredSystemVersion >> 16) & 0xfu,
+                meta.requiredSystemVersion ? " zeroed" : "");
 
         NcmContentMetaKey key {
             meta.header.id,

--- a/tests/test_content_meta.cpp
+++ b/tests/test_content_meta.cpp
@@ -1,0 +1,110 @@
+// Tests for the CNMT meta-record patch (issue #60): a title stamped for newer
+// firmware must not keep required_system_version in the installed meta
+// record, or HOS refuses to launch it with an "update required" nag. Only the
+// db record is patched — the NCA payloads stay byte-identical.
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "install/content_meta.hpp"
+
+using pipensx::install::kMetaTypeAddOnContent;
+using pipensx::install::kMetaTypeApplication;
+using pipensx::install::kMetaTypePatch;
+using pipensx::install::patchRequiredSystemVersion;
+
+namespace {
+
+// Encoding: (major << 26) | (minor << 20) | (micro << 16).
+constexpr uint32_t kRsv21_1_0 = (21u << 26) | (1u << 20) | (0u << 16);
+
+uint32_t u32At(const std::vector<uint8_t>& data, size_t offset) {
+    uint32_t value = 0;
+    std::memcpy(&value, data.data() + offset, sizeof(value));
+    return value;
+}
+
+} // namespace
+
+int main() {
+    // Sanity: 21.1.0 encodes to 0x54100000.
+    assert(kRsv21_1_0 == 0x54100000u);
+
+    // Application meta: patch_id (offset 0) and required_application_version
+    // (offset 12) untouched, RSV at offset 8 zeroed, original value returned.
+    {
+        std::vector<uint8_t> header(0x20, 0xAB);
+        std::memcpy(header.data() + 8, &kRsv21_1_0, sizeof(kRsv21_1_0));
+        const std::vector<uint8_t> original = header;
+
+        const uint32_t rsv = patchRequiredSystemVersion(
+            header.data(), static_cast<uint16_t>(header.size()),
+            kMetaTypeApplication);
+        assert(rsv == kRsv21_1_0);
+        assert(u32At(header, 8) == 0);
+        assert(std::memcmp(header.data(), original.data(), 8) == 0);
+        assert(std::memcmp(header.data() + 12, original.data() + 12,
+                           header.size() - 12) == 0);
+    }
+
+    // Patch meta: application_id (offset 0) and extended_data_size (offset
+    // 12, delta history size) untouched, RSV at the same offset 8 zeroed.
+    {
+        std::vector<uint8_t> header(0x18, 0xCD);
+        const uint32_t extendedDataSize = 0xDEADBEEF;
+        std::memcpy(header.data() + 12, &extendedDataSize,
+                    sizeof(extendedDataSize));
+        std::memcpy(header.data() + 8, &kRsv21_1_0, sizeof(kRsv21_1_0));
+        const std::vector<uint8_t> original = header;
+
+        const uint32_t rsv = patchRequiredSystemVersion(
+            header.data(), static_cast<uint16_t>(header.size()),
+            kMetaTypePatch);
+        assert(rsv == kRsv21_1_0);
+        assert(u32At(header, 8) == 0);
+        assert(u32At(header, 12) == extendedDataSize);
+        assert(std::memcmp(header.data(), original.data(), 8) == 0);
+    }
+
+    // AddOnContent passes through: offset 8 is required_application_version.
+    {
+        std::vector<uint8_t> header(0x18, 0xAB);
+        const uint32_t appVersion = 0x12345678;
+        std::memcpy(header.data() + 8, &appVersion, sizeof(appVersion));
+        const std::vector<uint8_t> original = header;
+
+        const uint32_t rsv = patchRequiredSystemVersion(
+            header.data(), static_cast<uint16_t>(header.size()),
+            kMetaTypeAddOnContent);
+        assert(rsv == 0);
+        assert(header == original);
+    }
+
+    // Other meta types (Delta = 0x83) pass through.
+    {
+        std::vector<uint8_t> header(0x10, 0xAB);
+        const std::vector<uint8_t> original = header;
+
+        const uint32_t rsv = patchRequiredSystemVersion(
+            header.data(), static_cast<uint16_t>(header.size()), 0x83);
+        assert(rsv == 0);
+        assert(header == original);
+    }
+
+    // Extended headers shorter than 12 bytes pass through.
+    {
+        std::vector<uint8_t> header(8, 0xAB);
+        const std::vector<uint8_t> original = header;
+
+        const uint32_t rsv = patchRequiredSystemVersion(
+            header.data(), static_cast<uint16_t>(header.size()),
+            kMetaTypeApplication);
+        assert(rsv == 0);
+        assert(header == original);
+    }
+
+    std::printf("test_content_meta: all ok\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #60.

HOS gates title launch on `required_system_version` from the CNMT extended header **as stored in the content meta database**, so a title stamped for newer firmware refuses to launch with the "update required" nag even though its NCAs installed byte-identically. Awoo/Tinfoil zero the same field at install; only the db meta record is patched — NCA payloads on storage stay untouched (so DBI's integrity check still passes).

## Changes

- **`src/install/content_meta.hpp`** (new): pure byte-level `patchRequiredSystemVersion()` — zeroes the u32 at extended-header offset 8 for Application (0x80) / Patch (0x81) metas, returns the original value, passes everything else through. Lives in a shared header because `install_backend_switch.cpp` is `__SWITCH__`-only and can't be unit-tested on PC. A `static_assert` in the backend ties the constants to libnx's `NcmContentMetaType`.
- **`install_backend_switch.cpp`**:
  - `readPackagedMeta()` patches the extended header right after copying it — the single point feeding both the early-CNMT path and `commitPackage`, so both paths get the patch. AddOnContent (whose offset 8 is `required_application_version`) is untouched; the patch's `extended_data_size` (offset 12, delta history size) is preserved.
  - The `CNMT parsed` log now prints `rsv=0x%08x (%u.%u.%u) zeroed` (original value, decoded major.minor.micro) so future "requires update" reports are triageable from `pipensx.log` alone.
- **`tests/test_content_meta.cpp`** (new): patch offset/size for both meta types, AddOnContent/Delta pass-through, short-header pass-through, and the 21.1.0 → `0x54100000` encoding.

## Verification

- [x] `make -f Makefile.pc test` — full suite green, new test included
- [x] `make switch` — NRO builds clean

## Not covered (out of scope, per issue caveats)

- On-device launch verification on a 19.x console with a 21.1.0-stamped package (needs a console).
- Standard-crypto conversion for NCAs encrypted with newer master keys, SDK-service compatibility — the pure RSV gate is the only thing patched.