### PR TITLE
Keep combo-dump metadata rows per title id.

### DIFF
--- a/src/app/game_metadata_service.cpp
+++ b/src/app/game_metadata_service.cpp
@@ -739,20 +739,32 @@ bool GameMetadataService::loadCachedSnapshot(MetadataSnapshot& snapshot,
 void GameMetadataService::recomputePlayerSummary() {
     availableModes_ = 0;
     localPlayerCounts_ = false;
-    for (const auto& entry : byHash_) {
-        availableModes_ |= entry.second.modes;
-        if (!entry.second.hasModes && entry.second.players >= 2)
+    for (const GameMetadata& entry : items_) {
+        availableModes_ |= entry.modes;
+        if (!entry.hasModes && entry.players >= 2)
             localPlayerCounts_ = true;
     }
 }
 
+void GameMetadataService::ingestItems(std::vector<GameMetadata> items) {
+    items_ = std::move(items);
+    byHash_.clear();
+    byHash_.reserve(items_.size());
+    for (size_t i = 0; i < items_.size(); ++i) {
+        if (byHash_.find(items_[i].infoHash) == byHash_.end())
+            byHash_[items_[i].infoHash] = i;
+    }
+    recomputePlayerSummary();
+    rebuildTitleIdIndex();
+}
+
 void GameMetadataService::rebuildTitleIdIndex() {
     std::unordered_map<std::string, std::vector<std::string>> next;
-    std::unordered_map<std::string, std::vector<std::string>> nextHashes;
-    next.reserve(byHash_.size());
-    nextHashes.reserve(byHash_.size());
-    for (const auto& entry : byHash_) {
-        const GameMetadata& metadata = entry.second;
+    std::unordered_map<std::string, std::vector<size_t>> nextItems;
+    next.reserve(items_.size());
+    nextItems.reserve(items_.size());
+    for (size_t i = 0; i < items_.size(); ++i) {
+        const GameMetadata& metadata = items_[i];
         if (metadata.latestVersion.empty())
             continue;
         std::string titleId = metadata.titleId;
@@ -761,7 +773,7 @@ void GameMetadataService::rebuildTitleIdIndex() {
                            return static_cast<char>(std::toupper(c));
                        });
         next[titleId].push_back(metadata.latestVersion);
-        nextHashes[titleId].push_back(metadata.infoHash);
+        nextItems[titleId].push_back(i);
     }
     for (auto& entry : next)
         std::sort(entry.second.begin(), entry.second.end(),
@@ -773,7 +785,7 @@ void GameMetadataService::rebuildTitleIdIndex() {
                       return a > b;
                   });
     byTitleId_ = std::move(next);
-    byTitleIdHashes_ = std::move(nextHashes);
+    byTitleIdItems_ = std::move(nextItems);
 }
 
 bool GameMetadataService::findByTitleId(
@@ -782,15 +794,12 @@ bool GameMetadataService::findByTitleId(
     std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c) {
         return static_cast<char>(std::toupper(c));
     });
-    auto it = byTitleIdHashes_.find(key);
-    if (it == byTitleIdHashes_.end())
+    auto it = byTitleIdItems_.find(key);
+    if (it == byTitleIdItems_.end())
         return false;
     out.reserve(out.size() + it->second.size());
-    for (const std::string& hash : it->second) {
-        const GameMetadata* entry = findByInfoHash(hash);
-        if (entry)
-            out.push_back(entry);
-    }
+    for (size_t index : it->second)
+        out.push_back(&items_[index]);
     // byHash_ iterates unordered, so pin a deterministic order: newest
     // bundled update first, info-hash as the tie-break.
     std::sort(out.begin(), out.end(), [](const GameMetadata* a,
@@ -818,9 +827,10 @@ bool GameMetadataService::collectLatestVersions(
 }
 
 bool GameMetadataService::load(std::string& error) {
+    items_.clear();
     byHash_.clear();
     byTitleId_.clear();
-    byTitleIdHashes_.clear();
+    byTitleIdItems_.clear();
     manifest_ = {};
     recomputePlayerSummary();
 
@@ -851,25 +861,15 @@ bool GameMetadataService::load(std::string& error) {
     std::vector<GameMetadata> items;
     if (!parseIndex(json, items, error))
         return false;
-    byHash_.reserve(items.size());
-    for (GameMetadata& item : items)
-        byHash_[item.infoHash] = std::move(item);
-    recomputePlayerSummary();
-    rebuildTitleIdIndex();
+    ingestItems(std::move(items));
     log_msg("[metadata] loaded %zu game matches from %s\n", byHash_.size(),
             bundledPath_.c_str());
     return true;
 }
 
 void GameMetadataService::adopt(MetadataSnapshot snapshot) {
-    std::unordered_map<std::string, GameMetadata> next;
-    next.reserve(snapshot.items.size());
-    for (GameMetadata& item : snapshot.items)
-        next[item.infoHash] = std::move(item);
-    byHash_ = std::move(next);
+    ingestItems(std::move(snapshot.items));
     manifest_ = std::move(snapshot.manifest);
-    recomputePlayerSummary();
-    rebuildTitleIdIndex();
     ++generation_;
 }
 
@@ -944,13 +944,27 @@ bool GameMetadataService::fetchLatest(MetadataSnapshot& snapshot,
 }
 
 const GameMetadata*
-GameMetadataService::findByInfoHash(const std::string& infoHash) const {
-    std::string key = infoHash;
-    std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c) {
-        return static_cast<char>(std::toupper(c));
-    });
-    auto it = byHash_.find(key);
-    return it == byHash_.end() ? nullptr : &it->second;
+GameMetadataService::findByInfoHash(const std::string& infoHash,
+                                    const std::string& titleId) const {
+    auto upper = [](std::string value) {
+        std::transform(value.begin(), value.end(), value.begin(),
+                       [](unsigned char c) {
+                           return static_cast<char>(std::toupper(c));
+                       });
+        return value;
+    };
+    const std::string hash = upper(infoHash);
+    const std::string wanted = upper(titleId);
+    if (!wanted.empty()) {
+        for (const GameMetadata& item : items_) {
+            if (item.infoHash == hash && upper(item.titleId) == wanted)
+                return &item;
+        }
+    }
+    auto it = byHash_.find(hash);
+    if (it == byHash_.end())
+        return nullptr;
+    return &items_[it->second];
 }
 
 bool GameMetadataService::refreshDetails(const std::string& titleId,

--- a/src/app/game_metadata_service.hpp
+++ b/src/app/game_metadata_service.hpp
@@ -111,7 +111,8 @@ public:
     bool load(std::string& error);
     bool fetchLatest(MetadataSnapshot& snapshot, std::string& error) const;
     void adopt(MetadataSnapshot snapshot);
-    const GameMetadata* findByInfoHash(const std::string& infoHash) const;
+    const GameMetadata* findByInfoHash(
+        const std::string& infoHash, const std::string& titleId = {}) const;
     // Appends every index entry matching titleId that carries a non-empty
     // latestVersion (the same entry set collectLatestVersions folds). The
     // caller chooses among bundles; returns false when the title has none.
@@ -194,13 +195,15 @@ private:
     };
 
     void imageWorkerMain() const;
-    // Refresh availableModes_/localPlayerCounts_ from byHash_. Called from
-    // every place that reassigns it (load, adopt).
+    // Refresh availableModes_/localPlayerCounts_ from items_. Called from
+    // every place that reassigns them (load, adopt).
     void recomputePlayerSummary();
     // Rebuild byTitleId_ (titleId → latestVersion strings) and
-    // byTitleIdHashes_ (titleId → info hashes) from byHash_. Called from every
-    // place that reassigns byHash_ (load, adopt).
+    // byTitleIdItems_ (titleId → indices into items_) from every index row.
+    // Combo dumps share an infoHash across title IDs; those rows must all
+    // stay, so this walks items_ rather than the unique-hash map.
     void rebuildTitleIdIndex();
+    void ingestItems(std::vector<GameMetadata> items);
     bool loadCachedSnapshot(MetadataSnapshot& snapshot,
                             std::string& error) const;
     ImageLoadResult loadImageInternal(const std::string& url,
@@ -228,14 +231,18 @@ private:
     mutable std::atomic<ImageNetwork> imageNetwork_{ImageNetwork::Full};
     mutable std::atomic<bool> stoppingRequested_{false};
     mutable bool stoppingImages_ = false;
-    std::unordered_map<std::string, GameMetadata> byHash_;
+    std::vector<GameMetadata> items_;
+    // infoHash → first items_ index. Catalog art looks up by torrent hash;
+    // combo dumps keep every title-id row in items_ and only the first hash
+    // wins here.
+    std::unordered_map<std::string, size_t> byHash_;
     // titleId (upper-case hex) → non-empty latestVersion of every entry that
-    // carries one. Built beside byHash_ (same UI-thread-only reassignment
+    // carries one. Built beside items_ (same UI-thread-only reassignment
     // rule) and consumed by collectLatestVersions().
     std::unordered_map<std::string, std::vector<std::string>> byTitleId_;
-    // titleId (upper-case hex) → info hashes of the same entry set as
+    // titleId (upper-case hex) → items_ indices of the same entry set as
     // byTitleId_. Consumed by findByTitleId() for update downloads.
-    std::unordered_map<std::string, std::vector<std::string>> byTitleIdHashes_;
+    std::unordered_map<std::string, std::vector<size_t>> byTitleIdItems_;
     MetadataManifest manifest_;
     uint64_t generation_ = 0;
     uint8_t availableModes_ = 0;

--- a/src/ui/detail/game_detail.hpp
+++ b/src/ui/detail/game_detail.hpp
@@ -107,7 +107,8 @@ public:
           alive_(std::make_shared<std::atomic<bool>>(true)),
           cancelled_(std::make_shared<std::atomic<bool>>(false)),
           autoInstall_(autoInstall), portInstall_(portInstall) {
-        const GameMetadata* found = metadata_->findByInfoHash(entry_.infoHash);
+        const GameMetadata* found =
+            metadata_->findByInfoHash(entry_.infoHash, entry_.titleId);
         presentation_ = resolveCatalogPresentation(entry_, found,
                                                    catalogTextPreference());
         titleId_ = presentation_.titleId;
@@ -1403,7 +1404,8 @@ private:
     }
 
     std::string latestVersionForEntry() const {
-        const GameMetadata* metadata = metadata_->findByInfoHash(entry_.infoHash);
+        const GameMetadata* metadata =
+            metadata_->findByInfoHash(entry_.infoHash, titleId_);
         return metadata ? metadata->latestVersion : std::string();
     }
 

--- a/src/ui/installed/installed_view.hpp
+++ b/src/ui/installed/installed_view.hpp
@@ -503,8 +503,11 @@ private:
                 tr("pipensx/installed/update_no_bundle"));
             return;
         }
+        CatalogEntry entry = *catalogEntry;
+        if (!titleId.empty())
+            entry.titleId = titleId;
         brls::Application::pushActivity(new GameDetailActivity(
-            *catalogEntry, "", manager_, metadata_, installed_, settings_,
+            std::move(entry), "", manager_, metadata_, installed_, settings_,
             [](const std::string&, const std::string&) {},
             [this, alive = alive_] {
                 brls::sync([this, alive] {

--- a/tests/test_catalog.cpp
+++ b/tests/test_catalog.cpp
@@ -369,6 +369,55 @@ void testFindByTitleIdBundles() {
     rmdir(root.c_str());
 }
 
+void testFindByTitleIdComboDump() {
+    const std::string root = "/tmp/pipensx-metadata-combo-" +
+        std::to_string(static_cast<long long>(getpid()));
+    const std::string bundled = root + "/bundled.json";
+    mkdir(root.c_str(), 0755);
+    writeTextFile(
+        bundled,
+        "[{\"infoHash\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\","
+        "\"titleId\":\"0100AAAA00000000\",\"name\":\"Super Mario Galaxy\","
+        "\"latestVersion\":\"131072\"},"
+        "{\"infoHash\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\","
+        "\"titleId\":\"0100BBBB00000000\",\"name\":\"Super Mario Galaxy 2\","
+        "\"latestVersion\":\"327680\"}]");
+
+    GameMetadataService metadata(root, bundled);
+    std::string error;
+    assert(metadata.load(error));
+
+    std::vector<const GameMetadata*> galaxy;
+    assert(metadata.findByTitleId("0100AAAA00000000", galaxy));
+    assert(galaxy.size() == 1);
+    assert(galaxy[0]->latestVersion == "131072");
+    assert(galaxy[0]->name == "Super Mario Galaxy");
+
+    std::vector<const GameMetadata*> galaxy2;
+    assert(metadata.findByTitleId("0100bbbb00000000", galaxy2));
+    assert(galaxy2.size() == 1);
+    assert(galaxy2[0]->latestVersion == "327680");
+
+    std::vector<std::string> versions;
+    assert(metadata.collectLatestVersions("0100AAAA00000000", versions));
+    assert(versions.size() == 1);
+    assert(versions[0] == "131072");
+
+    const GameMetadata* byHash = metadata.findByInfoHash(
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    assert(byHash && byHash->titleId == "0100AAAA00000000");
+    const GameMetadata* byPair = metadata.findByInfoHash(
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "0100BBBB00000000");
+    assert(byPair && byPair->latestVersion == "327680");
+    assert(byPair != byHash);
+
+    unlink(bundled.c_str());
+    rmdir((root + "/catalog/metadata").c_str());
+    rmdir((root + "/catalog/images").c_str());
+    rmdir((root + "/catalog").c_str());
+    rmdir(root.c_str());
+}
+
 void testPlayerFilterPredicate() {    GameMetadata igdb;
     igdb.players = 4;
     igdb.hasModes = true;
@@ -1444,6 +1493,7 @@ int main() {
     testMetadataIndexParsing();
     testMetadataIndexPlayerFields();
     testFindByTitleIdBundles();
+    testFindByTitleIdComboDump();
     testPlayerFilterPredicate();
     testMetadataSnapshotAcceptsVerifiedIndex();
     testMetadataSnapshotRejectsTamperedIndex();

--- a/tests/test_update_file_select.cpp
+++ b/tests/test_update_file_select.cpp
@@ -165,6 +165,33 @@ void testFallsBackToAllSkipWhenNothingMatches() {
     });
 }
 
+void testComboDumpDoesNotSelectOtherTitlePatch() {
+    TorrentPreview preview;
+    preview.files = {
+        package("Super Mario Galaxy [0100AAAA00000000][v0].nsp"),
+        package("Super Mario Galaxy [0100AAAA00000800][v131072].nsp"),
+        package("Super Mario Galaxy 2 [0100BBBB00000000][v0].nsp"),
+        package("Super Mario Galaxy 2 [0100BBBB00000800][v327680].nsp")};
+    expectSmartActions(preview, true, "0", "131072", "0100AAAA00000000", {
+        static_cast<uint8_t>(FileAction::Skip),
+        static_cast<uint8_t>(FileAction::Install),
+        static_cast<uint8_t>(FileAction::Skip),
+        static_cast<uint8_t>(FileAction::Skip),
+    });
+    expectSmartActions(preview, true, "0", "327680", "0100AAAA00000000", {
+        static_cast<uint8_t>(FileAction::Skip),
+        static_cast<uint8_t>(FileAction::Skip),
+        static_cast<uint8_t>(FileAction::Skip),
+        static_cast<uint8_t>(FileAction::Skip),
+    });
+    expectActions(preview, "327680", {
+        static_cast<uint8_t>(FileAction::Skip),
+        static_cast<uint8_t>(FileAction::Skip),
+        static_cast<uint8_t>(FileAction::Skip),
+        static_cast<uint8_t>(FileAction::Install),
+    }, "0100BBBB00000000");
+}
+
 void testSameVersionDifferentTitleIdUsesTitleId() {
     TorrentPreview preview;
     preview.files = {
@@ -412,6 +439,7 @@ int main() {
     testMarkerFallbackWithoutTags();
     testFallsBackToAllSkipWhenNothingMatches();
     testSameVersionDifferentTitleIdUsesTitleId();
+    testComboDumpDoesNotSelectOtherTitlePatch();
     testSmartInstallIncludesApplicableDlc();
     testSmartInstallSkipsBaseWhenInstalledButKeepsDlc();
     testSmartInstallLeavesUnknownPackagesSkipped();


### PR DESCRIPTION
Galaxy and Galaxy 2 share scene torrents; last-write-wins on info-hash made one game inherit the other's latestVersion.