### PR TITLE
fix(debrid): sequential fetch for RD stream-install (bugs 1–4)

### DIFF
--- a/src/app/debrid_transfer.cpp
+++ b/src/app/debrid_transfer.cpp
@@ -562,6 +562,10 @@ Step pollUntilReady(RunContext& ctx) {
                     DebridTaskSpec::ResolvedFile file;
                     file.path = sanitizeRelative(info.files[i].path, info.name,
                                                  pathOk);
+                    if (!pathOk || file.path.empty())
+                        file.path = baseName(info.files[i].path);
+                    while (!file.path.empty() && file.path.front() == '/')
+                        file.path.erase(file.path.begin());
                     file.localPath = file.path;
                     file.bytes = info.files[i].bytes;
                     file.action = !selected(ctx.spec, i, info.files[i])
@@ -569,8 +573,6 @@ Step pollUntilReady(RunContext& ctx) {
                         : installs(ctx.spec, i, info.files[i])
                             ? static_cast<uint8_t>(FileAction::Install)
                             : static_cast<uint8_t>(FileAction::Download);
-                    if (!pathOk)
-                        file.path = info.files[i].path;
                     resolved.push_back(std::move(file));
                 }
                 ctx.spec.filesResolved(resolved);
@@ -605,6 +607,17 @@ bool shouldEmitProgress(Clock::time_point& lastEmit) {
         return true;
     }
     return false;
+}
+
+// One TCP stream from offset to EOF. Stream-install uses this instead of
+// fetchOrdered: parallel Range workers on the same debrid CDN URL corrupt
+// the byte stream (RD returns 206 but pipensx sees non-PFS0 payloads).
+bool fetchSequential(const RangeFetcher& fetcher, const std::string& url,
+                     uint64_t offset,
+                     const std::function<bool(const uint8_t*, size_t)>& sink,
+                     const std::function<bool()>& cancelled,
+                     std::string& error) {
+    return fetcher(url, offset, 0, sink, cancelled, error);
 }
 
 // Pull [offset, totalBytes) through the injected fetcher. Several Range
@@ -977,9 +990,8 @@ Step attemptStreamInstall(RunContext& ctx, const DebridFile& file,
             ctx.packageDownloadedBytes.fetch_add(n);
             return queue.push(data, n);
         };
-        fetchOk = fetchOrdered(ctx.fetcher, url, 0, file.bytes,
-                               maximumBuffered / 2, sink, *ctx.shouldStop,
-                               fetchError);
+        fetchOk = fetchSequential(ctx.fetcher, url, 0, sink, *ctx.shouldStop,
+                                  fetchError);
         queue.finish();
     });
 

--- a/src/app/task_files.cpp
+++ b/src/app/task_files.cpp
@@ -361,8 +361,10 @@ bool saveTaskFileManifest(const std::string& appRoot,
 #endif
     ok = std::fclose(output) == 0 && ok;
     if (!ok || std::rename(temporary.c_str(), path.c_str()) != 0) {
+        const int saveErr = errno;
         std::remove(temporary.c_str());
-        error = "Unable to save task file manifest.";
+        error = "Unable to save task file manifest (errno=" +
+                std::to_string(saveErr) + ").";
         return false;
     }
     return true;

--- a/tests/test_debrid_transfer.cpp
+++ b/tests/test_debrid_transfer.cpp
@@ -691,6 +691,103 @@ void testStreamInstallCoalescesTinyChunks() {
     assert(last.packagesInstalled == 1);
 }
 
+void testStreamInstallLargeFileUsesSequentialFetch() {
+    const std::string root = "/tmp/pipensx-torbox-stream-large-test";
+    system(("rm -rf " + root).c_str());
+    mkdir(root.c_str(), 0755);
+    const std::string data = root + "/data";
+    mkdir(data.c_str(), 0755);
+
+    const size_t size = 10 * 1024 * 1024;
+    std::vector<uint8_t> nca(size, 0x2a);
+    std::vector<uint8_t> nsp =
+        makePfs0({{"00112233445566778899aabbccddeeff.nca", nca}});
+    std::string content(nsp.begin(), nsp.end());
+
+    int rangedCalls = 0;
+    int sequentialCalls = 0;
+    RangeFetcher fetcher = [&](const std::string&, uint64_t offset,
+                               uint64_t endExclusive,
+                               const std::function<bool(const uint8_t*, size_t)>&
+                                   sink,
+                               const std::function<bool()>&, std::string& error) {
+        if (endExclusive != 0) {
+            ++rangedCalls;
+            error = kDebridRangeNotSupported;
+            return false;
+        }
+        ++sequentialCalls;
+        std::string slice = content.substr(static_cast<size_t>(offset));
+        return sink(reinterpret_cast<const uint8_t*>(slice.data()),
+                    slice.size());
+    };
+
+    std::vector<std::pair<std::string, std::string>> script = {
+        {"mylist", infoReadyJson("Example/game.nsp", content.size())},
+        {"requestdl", "{\"success\":true,\"data\":\"https://x/dl\"}"},
+    };
+    TorboxProvider provider("k", scriptedTransport(&script));
+    DebridTransfer transfer(provider, fetcher);
+
+    DebridTaskSpec spec;
+    spec.taskId = "aabbccddaabbccddaabbccddaabbccddaabbccdd";
+    spec.debridId = "42";
+    spec.dataPath = data;
+    spec.workingRoot = root;
+    spec.mode = TransferMode::StreamInstall;
+
+    std::string debridId;
+    std::string error;
+    DebridProgress last;
+    DebridRunResult result = transfer.run(
+        spec, [] { return false; },
+        [&last](const DebridProgress& p) { last = p; }, debridId, error);
+    assert(result == DebridRunResult::Finished);
+    assert(rangedCalls == 0);
+    assert(sequentialCalls >= 1);
+    assert(last.status == DownloadStatus::Installed);
+    assert(last.packagesInstalled == 1);
+}
+
+void testFilesResolvedStripsLeadingSlash() {
+    const std::string root = "/tmp/pipensx-torbox-slash-path-test";
+    system(("rm -rf " + root).c_str());
+    mkdir(root.c_str(), 0755);
+    const std::string data = root + "/data";
+    mkdir(data.c_str(), 0755);
+
+    std::string content(1000, 'p');
+    std::vector<std::pair<std::string, std::string>> script = {
+        {"createtorrent", "{\"success\":true,\"data\":{\"torrent_id\":42}}"},
+        {"mylist", infoReadyJson("/Example/file.bin", content.size())},
+        {"requestdl", "{\"success\":true,\"data\":\"https://x/dl\"}"},
+    };
+    TorboxProvider provider("k", scriptedTransport(&script));
+    DebridTransfer transfer(provider, memoryFetcher(content));
+
+    DebridTaskSpec spec;
+    spec.taskId = "aabbccddaabbccddaabbccddaabbccddaabbccdd";
+    spec.magnet = "magnet:?xt=urn:btih:" + spec.taskId;
+    spec.dataPath = data;
+    spec.workingRoot = root;
+    spec.mode = TransferMode::DownloadOnly;
+    std::vector<DebridTaskSpec::ResolvedFile> resolvedFiles;
+    spec.filesResolved = [&resolvedFiles](
+                             const std::vector<DebridTaskSpec::ResolvedFile>&
+                                 files) { resolvedFiles = files; };
+
+    std::string debridId;
+    std::string error;
+    DebridRunResult result = transfer.run(
+        spec, [] { return false; }, [](const DebridProgress&) {}, debridId,
+        error);
+    assert(result == DebridRunResult::Finished);
+    assert(resolvedFiles.size() == 1);
+    assert(resolvedFiles[0].path == "Example/file.bin");
+    assert(resolvedFiles[0].localPath == "Example/file.bin");
+    assert(resolvedFiles[0].path.front() != '/');
+}
+
 void testBuildRichMagnet() {
     std::string m = buildRichMagnet(
         "0123456789abcdef0123456789abcdef01234567",
@@ -722,6 +819,8 @@ int main() {
     testOutOfOrderRangesAssembleInOrder();
     testRangeIgnoredFallsBackToSequential();
     testStreamInstallCoalescesTinyChunks();
+    testStreamInstallLargeFileUsesSequentialFetch();
+    testFilesResolvedStripsLeadingSlash();
     testBuildRichMagnet();
     std::printf("test_debrid_transfer ok\n");
     return 0;

--- a/tests/test_task_files.cpp
+++ b/tests/test_task_files.cpp
@@ -71,6 +71,16 @@ int main() {
     assert(!taskFilePathIsFatCompatible("switch/Game/bad:name"));
     assert(!taskFilePathIsFatCompatible("switch/" + std::string(256, 'a')));
 
+    TaskFileManifest slashManifest;
+    slashManifest.taskId = "slashpathhash0123456789012345678901234";
+    TaskFileRecord slashRecord;
+    slashRecord.logicalPath = "Example/file.bin";
+    slashRecord.localPath = "Example/file.bin";
+    slashRecord.size = 1000;
+    slashRecord.action = TaskFileAction::Download;
+    slashManifest.files.push_back(slashRecord);
+    assert(saveTaskFileManifest(root, slashManifest, error));
+
     removeTaskFileManifest(root, preview.infoHash);
     assert(!loadTaskFileManifest(root, preview.infoHash, loaded, error));
     fs::remove_all(root);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Real-Debrid stream-install failures reported in bugs №1–4 (PFS0 / installer rejected, `rc=23`, `files=2 links=1`).

**Root cause:** `attemptStreamInstall` used parallel Range fetch (4 workers × 4 MiB) on debrid CDN URLs. Real-Debrid does not tolerate multiple concurrent Range requests on the same unrestricted link — workers abort each other and `PackageStream` receives non-PFS0 bytes.

**Changes:**
- Stream-install now uses `fetchSequential` (single HTTPS connection). Download-only (`fetchAppend`) still uses parallel ranges for TorBox/RD.
- Debrid `filesResolved` paths are normalized for task-file manifests (no leading `/`, `baseName` fallback instead of raw RD path).
- `saveTaskFileManifest` reports `errno` on IO failure for easier Switch triage.

## Tests

- `testStreamInstallLargeFileUsesSequentialFetch` — 10 MiB PFS0 stream install asserts zero parallel range calls
- `testFilesResolvedStripsLeadingSlash` — TorBox path `/Example/file.bin` → `Example/file.bin`
- `test_task_files` — manifest save with normalized debrid-style paths

```sh
./build-pc/tests/test_debrid_transfer
./build-pc/tests/test_task_files
./build-pc/tests/test_realdebrid_provider
```

Full `make -f Makefile.pc test` fails in this environment on `test_port_archive` (missing `7z`); unrelated to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c65db68c-8d08-4d9e-ad9c-3130da724256?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c65db68c-8d08-4d9e-ad9c-3130da724256&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

