### PR TITLE
Fix updater helper publish when pipensx-updater.nro already exists

### DIFF
--- a/src/app/update_service.cpp
+++ b/src/app/update_service.cpp
@@ -540,12 +540,26 @@ bool UpdateService::install(const ReleaseInfo& release, std::string& error) cons
         return false;
     }
     if (rename(helperTemporary.c_str(), helper.c_str()) != 0) {
-        helperError = std::strerror(errno);
-        unlink(helperTemporary.c_str());
-        unlink(marker.c_str());
-        unlink(temporary.c_str());
-        error = "Unable to publish update helper: " + helperError;
-        return false;
+        const int renameErrno = errno;
+        bool helperPublished = false;
+        if (renameErrno == EEXIST) {
+            if (unlink(helper.c_str()) != 0 && errno != ENOENT) {
+                helperError = std::strerror(errno);
+            } else if (rename(helperTemporary.c_str(), helper.c_str()) == 0) {
+                helperPublished = true;
+            } else {
+                helperError = std::strerror(errno);
+            }
+        } else {
+            helperError = std::strerror(renameErrno);
+        }
+        if (!helperPublished) {
+            unlink(helperTemporary.c_str());
+            unlink(marker.c_str());
+            unlink(temporary.c_str());
+            error = "Unable to publish update helper: " + helperError;
+            return false;
+        }
     }
 #ifdef __SWITCH__
     const Result commit = fsdevCommitDevice("sdmc");

--- a/tests/test_update_service.cpp
+++ b/tests/test_update_service.cpp
@@ -17,6 +17,7 @@ constexpr const char* Target = "/tmp/pipensx-update-test.nro";
 constexpr const char* HelperSource = "/tmp/pipensx-updater-fixture.nro";
 
 bool emulateSwitchRename = false;
+bool emulateSwitchHelperRename = false;
 bool failHelperPublish = false;
 
 extern "C" int __real_rename(const char* oldPath, const char* newPath);
@@ -37,6 +38,13 @@ extern "C" int __wrap_rename(const char* oldPath, const char* newPath) {
             errno = EEXIST;
             return -1;
         }
+    }
+    if (emulateSwitchHelperRename &&
+        std::strcmp(oldPath, "/tmp/pipensx-updater.nro.tmp") == 0 &&
+        std::strcmp(newPath, "/tmp/pipensx-updater.nro") == 0 &&
+        access(newPath, F_OK) == 0) {
+        errno = EEXIST;
+        return -1;
     }
     return __real_rename(oldPath, newPath);
 }
@@ -289,6 +297,40 @@ void testShutdownInterruptsRetryWait() {
     assert(attempts.load() == 1);
 }
 
+void testHelperPublishReplacesExistingHelperOnFat32() {
+    unlink(Target);
+    unlink("/tmp/pipensx-update-test.nro.update");
+    unlink("/tmp/pipensx-update-test.nro.update.sha256");
+    unlink("/tmp/pipensx-updater.nro.tmp");
+    write(Target, "old");
+    write(HelperSource, "minimal updater helper");
+    write("/tmp/pipensx-updater.nro", "previous helper");
+    const std::string payload = "new verified pipensx nro";
+    const std::string checksum =
+        "9dc1034a694baa2d68b032ed446fbc9b170975306c571202e99ff741821365b4";
+    pipensx::UpdateService service(Target,
+        [checksum](const std::string&, size_t, std::string& body,
+                   std::string&) { body = checksum + "  pipensx.nro\n"; return true; },
+        [payload](const std::string&, const std::string& path, size_t,
+                  std::string&) { write(path, payload); return true; },
+        HelperSource);
+    pipensx::ReleaseInfo release{"v1.2.3",
+        "https://github.com/i3sey/pipensx/releases/download/v1.2.3/pipensx.nro",
+        "https://github.com/i3sey/pipensx/releases/download/v1.2.3/pipensx.nro.sha256"};
+    std::string error;
+    emulateSwitchHelperRename = true;
+    const bool installed = service.install(release, error);
+    emulateSwitchHelperRename = false;
+    assert(installed);
+    std::ifstream helper(service.helperPath(), std::ios::binary);
+    std::string bytes((std::istreambuf_iterator<char>(helper)), {});
+    assert(bytes == "minimal updater helper");
+    assert(access("/tmp/pipensx-updater.nro.tmp", F_OK) != 0);
+    service.discardStaged();
+    unlink(Target);
+    unlink(HelperSource);
+}
+
 void testHelperPublishFailurePreservesPreviousHelper() {
     unlink(Target);
     unlink("/tmp/pipensx-update-test.nro.update");
@@ -335,6 +377,7 @@ int main() {
     testTransientNetworkFailuresAreRetried();
     testInstallNeverTouchesRunningNro();
     testShutdownInterruptsRetryWait();
+    testHelperPublishReplacesExistingHelperOnFat32();
     testHelperPublishFailurePreservesPreviousHelper();
     std::puts("update service tests passed");
     return 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes self-update bugs #8 and #9 from the 1.4.1 bug triage: after the NRO download reaches 100%, publishing `pipensx-updater.nro` could fail with `Unable to publish update helper: File exists.` when a helper from a previous update attempt was still on the SD card.

On FAT32, `rename()` cannot replace an existing destination file. The updater now retries helper publish by unlinking the stale `pipensx-updater.nro` when the first `rename()` fails with `EEXIST`, matching the queue-state write pattern in `download_manager.cpp`. Other rename failures (e.g. I/O errors) still leave the previous helper untouched.

## Test plan

- [x] `build-pc/tests/test_update_service` — includes new `testHelperPublishReplacesExistingHelperOnFat32`
- [x] `build-pc/tests/test_update_transaction`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40521f56-a4ea-4f9a-a2b3-ce31c30442c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40521f56-a4ea-4f9a-a2b3-ce31c30442c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

