### PR TITLE
fix(install): mount CNMT from placeholder path before register

### DIFF
--- a/src/install/content_meta.hpp
+++ b/src/install/content_meta.hpp
@@ -5,6 +5,7 @@
 // byte-level logic lives here to stay unit-testable on the PC.
 
 #include <cstddef>
+#include <cstdio>
 #include <cstdint>
 #include <cstring>
 

--- a/src/install/content_meta.hpp
+++ b/src/install/content_meta.hpp
@@ -4,6 +4,7 @@
 // test suite. install_backend_switch.cpp is __SWITCH__-only, so the pure
 // byte-level logic lives here to stay unit-testable on the PC.
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 
@@ -38,6 +39,53 @@ inline uint32_t patchRequiredSystemVersion(uint8_t* extendedHeader,
                 sizeof(original));
     std::memset(extendedHeader + sizeof(uint64_t), 0, sizeof(original));
     return original;
+}
+
+// libnx Result layout (switch/result.h).
+constexpr uint32_t kFsResultModule = 2u;
+// ams::fs::RomNcaHeaderSignature1VerificationFailed (fs_results.hpp).
+constexpr uint32_t kFsRomNcaHeaderSignature1VerificationFailed = 4058u;
+
+// FSP IPC path buffers must be zero-filled to FS_MAX_PATH; libnx does not
+// always pad shorter paths (see vendor/libnx-ext/libnx-ipcext/ncm-ext.c).
+constexpr size_t kFspPathCapacity = 768u;
+
+inline uint32_t resultModule(uint32_t result) {
+    return result & 0x1FFu;
+}
+
+inline uint32_t resultDescription(uint32_t result) {
+    return (result >> 9) & 0x1FFFu;
+}
+
+inline void copyFspPath(char* out, size_t outSize, const char* path) {
+    if (!out || outSize == 0)
+        return;
+    std::memset(out, 0, outSize);
+    if (path)
+        std::strncpy(out, path, outSize - 1);
+}
+
+inline bool isRomNcaHeaderSignature1VerificationFailed(uint32_t result) {
+    return resultModule(result) == kFsResultModule &&
+           resultDescription(result) ==
+               kFsRomNcaHeaderSignature1VerificationFailed;
+}
+
+// Formats the user-facing CNMT mount failure. Returns bytes written, or 0 if
+// the buffer is too small.
+inline size_t formatCnmtOpenError(char* out, size_t outSize, uint32_t result) {
+    if (!out || outSize == 0)
+        return 0;
+    if (isRomNcaHeaderSignature1VerificationFailed(result)) {
+        return static_cast<size_t>(std::snprintf(
+            out, outSize,
+            "Unable to open CNMT NCA (NCA header signature verification "
+            "failed, 0x%08x).",
+            result));
+    }
+    return static_cast<size_t>(std::snprintf(
+        out, outSize, "Unable to open CNMT NCA (0x%08x).", result));
 }
 
 } // namespace pipensx::install

--- a/src/install/install_backend_switch.cpp
+++ b/src/install/install_backend_switch.cpp
@@ -250,16 +250,36 @@ struct ParsedMeta {
     uint32_t requiredSystemVersion = 0;
 };
 
+Result flushContentPlaceholders(NcmContentStorage* storage) {
+    if (!hosversionAtLeast(3, 0, 0))
+        return 0;
+    return ncmContentStorageFlushPlaceHolder(storage);
+}
+
+Result resolveCnmtNcaPath(NcmContentStorage* storage, const Content& content,
+                          char path[FS_MAX_PATH]) {
+    Result rc = flushContentPlaceholders(storage);
+    if (R_FAILED(rc))
+        return rc;
+    if (content.existing || content.registered) {
+        return ncmContentStorageGetPath(storage, path, FS_MAX_PATH,
+                                        &content.id);
+    }
+    return ncmContentStorageGetPlaceHolderPath(storage, path, FS_MAX_PATH,
+                                               &content.placeholder);
+}
+
 bool readPackagedMeta(const std::string& ncaPath, ParsedMeta& out,
                       std::string& error) {
+    char fspPath[FS_MAX_PATH] {};
+    copyFspPath(fspPath, sizeof(fspPath), ncaPath.c_str());
     FsFileSystem filesystem {};
     Result rc = fsOpenFileSystemWithId(&filesystem, 0,
-        FsFileSystemType_ContentMeta, ncaPath.c_str(),
+        FsFileSystemType_ContentMeta, fspPath,
         FsContentAttributes_All);
     if (R_FAILED(rc)) {
-        char text[96];
-        std::snprintf(text, sizeof(text),
-                      "Unable to open CNMT NCA (0x%08x).", rc);
+        char text[128];
+        formatCnmtOpenError(text, sizeof(text), rc);
         error = text;
         return false;
     }
@@ -682,6 +702,11 @@ public:
         // "sdmc:" devoptab path of the on-disk copy. Register the CNMT NCA so we
         // can mount it through NCM. On an already-installed title the CNMT NCA's
         // content id already exists (existing == true), so we never register here.
+        Result flushRc = flushContentPlaceholders(&storage_);
+        if (R_FAILED(flushRc)) {
+            errorResult("Unable to flush CNMT placeholder", flushRc);
+            return false;
+        }
         if (!metaContent->existing && !metaContent->registered) {
             Result rc = ncmContentStorageRegister(
                 &storage_, &metaContent->id, &metaContent->placeholder);
@@ -696,9 +721,8 @@ public:
             meta = earlyMeta_;
         } else {
             char metaNcaPath[FS_MAX_PATH];
-            Result pathRc = ncmContentStorageGetPath(&storage_, metaNcaPath,
-                                                     sizeof(metaNcaPath),
-                                                     &metaContent->id);
+            Result pathRc = resolveCnmtNcaPath(&storage_, *metaContent,
+                                               metaNcaPath);
             if (R_FAILED(pathRc)) {
                 errorResult("Unable to resolve CNMT NCA path", pathRc);
                 return false;
@@ -1215,22 +1239,19 @@ private:
     void prepareEarlyMeta(Content& metaContent) {
         if (earlyMetaValid_)
             return;
-        if (!metaContent.existing && !metaContent.registered) {
-            Result rc = ncmContentStorageRegister(
-                &storage_, &metaContent.id, &metaContent.placeholder);
-            if (R_FAILED(rc)) {
-                log_msg("[install] early CNMT register failed (0x%08x)\n", rc);
-                return;
-            }
-            metaContent.registered = true;
-        }
         char path[FS_MAX_PATH];
-        Result rc = ncmContentStorageGetPath(&storage_, path, sizeof(path),
-                                             &metaContent.id);
+        Result rc = resolveCnmtNcaPath(&storage_, metaContent, path);
         if (R_FAILED(rc)) {
-            log_msg("[install] early CNMT path failed (0x%08x)\n", rc);
+            log_msg("[install] early CNMT path failed (0x%08x) existing=%d "
+                    "id=%s\n",
+                    rc, metaContent.existing ? 1 : 0,
+                    hexBytes(metaContent.id.c, sizeof(metaContent.id.c)).c_str());
             return;
         }
+        log_msg("[install] early CNMT path existing=%d id=%s prefix='%.32s'\n",
+                metaContent.existing ? 1 : 0,
+                hexBytes(metaContent.id.c, sizeof(metaContent.id.c)).c_str(),
+                path);
         ParsedMeta meta;
         std::string parseError;
         if (!readPackagedMeta(path, meta, parseError)) {

--- a/tests/test_content_meta.cpp
+++ b/tests/test_content_meta.cpp
@@ -10,10 +10,17 @@
 
 #include "install/content_meta.hpp"
 
+using pipensx::install::copyFspPath;
+using pipensx::install::formatCnmtOpenError;
+using pipensx::install::isRomNcaHeaderSignature1VerificationFailed;
+using pipensx::install::kFspPathCapacity;
+using pipensx::install::kFsRomNcaHeaderSignature1VerificationFailed;
 using pipensx::install::kMetaTypeAddOnContent;
 using pipensx::install::kMetaTypeApplication;
 using pipensx::install::kMetaTypePatch;
 using pipensx::install::patchRequiredSystemVersion;
+using pipensx::install::resultDescription;
+using pipensx::install::resultModule;
 
 namespace {
 
@@ -103,6 +110,33 @@ int main() {
             kMetaTypeApplication);
         assert(rsv == 0);
         assert(header == original);
+    }
+
+    // FS Result decode: E5EB bug report used 0xaf5fb402 (module 2, desc 4058).
+    {
+        constexpr uint32_t kE5ebCnmtOpen = 0xaf5fb402u;
+        assert(resultModule(kE5ebCnmtOpen) == 2u);
+        assert(resultDescription(kE5ebCnmtOpen) ==
+               kFsRomNcaHeaderSignature1VerificationFailed);
+        assert(isRomNcaHeaderSignature1VerificationFailed(kE5ebCnmtOpen));
+        char text[160];
+        const size_t written =
+            formatCnmtOpenError(text, sizeof(text), kE5ebCnmtOpen);
+        assert(written > 0);
+        assert(std::strstr(text, "signature verification failed") != nullptr);
+        assert(std::strstr(text, "0xaf5fb402") != nullptr);
+    }
+
+    // copyFspPath zero-fills and truncates safely.
+    {
+        char path[kFspPathCapacity] {};
+        path[0] = 'x';
+        copyFspPath(path, sizeof(path), "registered:/a/b/c.nca");
+        assert(path[0] == 'r');
+        assert(std::strcmp(path, "registered:/a/b/c.nca") == 0);
+        assert(path[sizeof(path) - 1] == '\0');
+        for (size_t i = std::strlen(path) + 1; i < sizeof(path); ++i)
+            assert(path[i] == '\0');
     }
 
     std::printf("test_content_meta: all ok\n");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes bug #7 (QR E5EB): NSZ install failed at commit with `Unable to open CNMT NCA (0xaf5fb402)` — FS error 4058 (`RomNcaHeaderSignature1VerificationFailed`).

The early CNMT parse added in PERF_PLAN 3.4 registered the meta NCA mid-stream and mounted it via the registered NCM path. That left a fragile path: placeholder data might not be visible to FS until flushed, and a failed early mount still left `registered=true` before commit retried the same path.

## Changes

- **`prepareEarlyMeta`**: flush placeholder → `GetPlaceHolderPath` → parse. No mid-stream `Register`.
- **`commitPackage`**: flush → register (if needed) → `resolveCnmtNcaPath` → parse (or reuse early meta).
- **`readPackagedMeta`**: copy path into zero-filled `FS_MAX_PATH` buffer before `fsOpenFileSystemWithId` (libnx IPC quirk).
- **Diagnostics**: map FS 4058 to a readable CNMT open error; log `existing`, content id, and path prefix on early parse.
- **Tests**: `test_content_meta` covers Result decode for `0xaf5fb402` and `copyFspPath`.

## Verification

- `test_content_meta` — pass (compiled and run locally)
- `make -f Makefile.pc test` — not run (missing libcurl / borealis json in this VM)
- `make switch` — not run (`DEVKITPRO` not set)

## Manual test plan (Switch)

1. Install Pokemon Mystery Dungeon Rescue Team DX NSZ (same torrent as E5EB) after a successful prior install.
2. Confirm CNMT parses (`CNMT parsed early` or successful commit) and title appears in Installed.
3. If it still fails, capture QR — error should now mention signature verification explicitly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28f2d54b-4016-493d-8a40-db54c0c5ab01?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28f2d54b-4016-493d-8a40-db54c0c5ab01&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

