### PR TITLE
fix(catalog): trust GitHub TLS on Switch with bundled CA roots

### DIFF
--- a/src/app/catalog_service.cpp
+++ b/src/app/catalog_service.cpp
@@ -155,8 +155,7 @@ bool httpGet(const std::string& url, std::string& body, std::string& error,
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 45L);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeHttp);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buffer);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+    curlApplyTrustedSsl(curl);
     curlPinHttpsOnly(curl);
     curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
     CURLcode result = curl_easy_perform(curl);

--- a/src/app/game_metadata_service.cpp
+++ b/src/app/game_metadata_service.cpp
@@ -1,4 +1,5 @@
 #include "game_metadata_service.hpp"
+#include "curl_https.hpp"
 #include "snapshot_zstd.hpp"
 
 extern "C" {
@@ -194,8 +195,12 @@ bool httpGetOnce(const std::string& url, size_t limit,
         });
     curl_easy_setopt(curl, CURLOPT_XFERINFODATA,
                      const_cast<std::atomic<bool>*>(stopping));
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, verifyTls ? 1L : 0L);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, verifyTls ? 2L : 0L);
+    if (verifyTls)
+        curlApplyTrustedSsl(curl);
+    else {
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    }
     curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
     CURLcode result = curl_easy_perform(curl);
     long status = 0;

--- a/src/ui/catalog/catalog_helpers.hpp
+++ b/src/ui/catalog/catalog_helpers.hpp
@@ -10,6 +10,7 @@
 
 #include "app/catalog_presentation.hpp"
 #include "app/catalog_service.hpp"
+#include "app/curl_https.hpp"
 #include "ui/i18n.hpp"
 #include "app/game_metadata_service.hpp"
 #include "ui/common/async_image.hpp"
@@ -26,6 +27,12 @@ inline std::string catalogLower(std::string value) {
                        return static_cast<char>(std::tolower(c));
                    });
     return value;
+}
+
+inline std::string formatCatalogRefreshError(const std::string& error) {
+    if (isSslCertificateErrorMessage(error))
+        return tr("pipensx/debrid/ssl_cert_hint");
+    return error;
 }
 
 inline std::string classifyResolveFailure(const std::string& error) {

--- a/src/ui/catalog/catalog_view.hpp
+++ b/src/ui/catalog/catalog_view.hpp
@@ -1751,6 +1751,9 @@ private:
                              bool catalogOk, bool metadataOk,
                              const std::string& catalogError,
                              const std::string& metadataError) {
+        const std::string catalogMsg = formatCatalogRefreshError(catalogError);
+        const std::string metadataMsg =
+            formatCatalogRefreshError(metadataError);
         if (fetchCatalog && fetchMetadata) {
             if (catalogOk && metadataOk) {
                 brls::Application::notify(
@@ -1759,25 +1762,25 @@ private:
             } else if (catalogOk) {
                 brls::Application::notify(
                     tr("pipensx/catalog/updated_catalog_artwork_failed",
-                       metadataError));
+                       metadataMsg));
             } else if (metadataOk) {
                 brls::Application::notify(
                     tr("pipensx/catalog/updated_artwork_catalog_failed",
-                       catalogError));
+                       catalogMsg));
             } else {
                 brls::Application::notify(
-                    tr("pipensx/catalog/updated_both_failed", catalogError,
-                       metadataError));
+                    tr("pipensx/catalog/updated_both_failed", catalogMsg,
+                       metadataMsg));
             }
         } else if (fetchCatalog) {
             brls::Application::notify(catalogOk
                 ? tr("pipensx/catalog/updated_catalog",
                      catalog_->entries().size())
-                : catalogError);
+                : catalogMsg);
         } else if (fetchMetadata) {
             brls::Application::notify(metadataOk
                 ? tr("pipensx/catalog/updated_artwork", metadata_->size())
-                : metadataError);
+                : metadataMsg);
         }
     }
 

--- a/src/ui/settings/settings_panels.hpp
+++ b/src/ui/settings/settings_panels.hpp
@@ -1056,7 +1056,7 @@ private:
                 if (!ok) {
                     diagnostic_error("catalog", "settings_refresh", "error=%s",
                                      error.c_str());
-                    brls::Application::notify(error);
+                    brls::Application::notify(formatCatalogRefreshError(error));
                     return;
                 }
                 brls::Application::notify(
@@ -1104,7 +1104,7 @@ private:
                 if (!ok) {
                     diagnostic_error("metadata", "settings_refresh",
                                      "error=%s", error.c_str());
-                    brls::Application::notify(error);
+                    brls::Application::notify(formatCatalogRefreshError(error));
                     return;
                 }
                 if (onMetadataRefreshed_)
@@ -1637,7 +1637,7 @@ private:
                         tr("pipensx/settings/install_failed"));
                     diagnostic_error("update", "install", "error=%s",
                                      error.c_str());
-                    brls::Application::notify(error);
+                    brls::Application::notify(formatCatalogRefreshError(error));
                     return;
                 }
                 updateAction_->setDetailText(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes bug #10: catalog and metadata refresh failing on Switch with `SSL peer certificate or SSH remote key was not OK` after 1.4.1.

Peer verification was enabled for catalog fetches in `659c57a`, but unlike debrid clients (`abf8316`) the bundled `romfs:/ssl/cacert.pem` was never loaded. On Switch the system CA store cannot validate GitHub's chain, so every network refresh failed while the bundled romfs catalog still loaded.

## Changes

- **`catalog_service.cpp`**: use `curlApplyTrustedSsl()` in `httpGet()` instead of manual `SSL_VERIFYPEER`/`SSL_VERIFYHOST`
- **`game_metadata_service.cpp`**: call `curlApplyTrustedSsl()` when `verifyTls` is true in `httpGetOnce()` (manifest/index fetches)
- **UI**: surface `pipensx/debrid/ssl_cert_hint` when verification still fails (e.g. wrong console clock) via `formatCatalogRefreshError()` in catalog refresh notifications

## Testing

- `build-pc/tests/test_ssl_cacert` — pass
- `build-pc/tests/test_catalog` — pass
- Changed objects compile cleanly on PC
- `make switch` not run (DEVKITPRO unavailable in cloud agent environment)

## Expected result on Switch

Settings → update catalog should succeed; log shows `[catalog] refreshed N entries from https://raw.githubusercontent.com/...` without SSL peer certificate diagnostics.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64283b59-ec5f-4fd8-a2dc-c04131c3d173?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64283b59-ec5f-4fd8-a2dc-c04131c3d173&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

