### PR TITLE
ci(release): tag-triggered 1.4.4 draft with release notes

### DIFF
--- a/.github/workflows/switch-release.yml
+++ b/.github/workflows/switch-release.yml
@@ -5,11 +5,18 @@ name: switch-release
 # review before it goes public.
 
 on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
     inputs:
       version:
-        description: "Release tag (e.g. v0.3.0)"
+        description: "Release tag (e.g. 1.4.4)"
         required: true
+        type: string
+      notes:
+        description: "Optional release notes (overrides releases/<version>-notes.md)"
+        required: false
         type: string
 
 permissions:
@@ -22,6 +29,7 @@ jobs:
     container:
       image: devkitpro/devkita64:latest
     env:
+      RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
       DEVKITPRO: /opt/devkitpro
       # ubuntu-latest is 2-core/7GB; even 2 concurrent heavy TUs from this
       # template-heavy C++ tree (borealis/nanovg) exceed available RAM and
@@ -97,7 +105,7 @@ jobs:
 
       - name: Build pipensx.nro
         env:
-          PIPENSX_VERSION: ${{ inputs.version }}
+          PIPENSX_VERSION: ${{ env.RELEASE_VERSION }}
         run: |
           PIPENSX_VERSION="${PIPENSX_VERSION#v}" make switch
           sha256sum build-switch/pipensx.nro > build-switch/pipensx.nro.sha256
@@ -136,15 +144,32 @@ jobs:
           name: pipensx-nro
           path: dist
 
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: releases
+          sparse-checkout-cone-mode: false
+
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+          DISPATCH_NOTES: ${{ github.event_name == 'workflow_dispatch' && inputs.notes || '' }}
         run: |
-          gh release create "${{ inputs.version }}" \
+          set -eu
+          version="${RELEASE_VERSION#v}"
+          notes_file="releases/${version}-notes.md"
+          notes_args="--generate-notes"
+          if [ -n "${DISPATCH_NOTES}" ]; then
+            printf '%s\n' "${DISPATCH_NOTES}" > /tmp/release-notes.md
+            notes_args="--notes-file /tmp/release-notes.md"
+          elif [ -f "${notes_file}" ]; then
+            notes_args="--notes-file ${notes_file}"
+          fi
+          gh release create "${version}" \
             dist/pipensx.nro \
             dist/pipensx.nro.sha256 \
             dist/SDOut.zip \
             --repo "${{ github.repository }}" \
-            --title "${{ inputs.version }}" \
+            --title "${version}" \
             --draft \
-            --generate-notes
+            ${notes_args}

--- a/releases/1.4.4-notes.md
+++ b/releases/1.4.4-notes.md
@@ -1,0 +1,27 @@
+## What's new since 1.4.1
+
+**In short:** the app is more stable, installs and downloads are more reliable, and the UI is clearer.
+
+### Game and port installation
+
+- Compressed games (NSZ) install better when the SD card is low on space.
+- Ports copied to `SD:/switch/` are more reliable, including large ones — with progress shown.
+- Fewer failures when reinstalling the same game.
+- Torrents with lots of files (mods, large ports) no longer break due to file limits.
+
+### Real-Debrid and downloads
+
+- Both stream-install and regular download via Real-Debrid are more stable.
+- If a magnet link fails, the app tries downloading via `.torrent` instead.
+- Clearer messages when the wrong file type arrives (e.g. XCI instead of NSP).
+
+### Catalog and updates
+
+- The on-console catalog updates from GitHub without TLS issues.
+- pipensx self-update no longer fails if the updater file already exists.
+
+### Interface
+
+- Empty lists (catalog, downloads, My Games) now show helpful hints on what to do next.
+- Easier navigation and focus when lists refresh.
+- Torrent file tree is more compact — mods no longer take over the whole screen.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `releases/1.4.4-notes.md` (English user-facing changelog) and updates `switch-release` to:

- run on semver tag push (e.g. `1.4.4`);
- use `releases/<version>-notes.md` for draft release text when present;
- keep manual `workflow_dispatch` with optional inline notes.

After merge, push tag `1.4.4` on `main` to build the draft release via CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fc90953-0cbe-4620-9c58-c2a73b1f5458?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fc90953-0cbe-4620-9c58-c2a73b1f5458&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

